### PR TITLE
Update Discover page heading to “Bienvenue !”

### DIFF
--- a/frontend/src/components/Flowbox/Discover.js
+++ b/frontend/src/components/Flowbox/Discover.js
@@ -227,7 +227,7 @@ export default function Discover() {
 
       <Box className="intro">
         <Typography component="h2" variant="h1">
-          Bonne écoute !
+          Bienvenue !
         </Typography>
         <Typography component="span" variant="body1">
           Découvre la chanson déposée par le passant·e précédent


### PR DESCRIPTION
### Motivation
- Harmoniser le message d'accueil de la page Discover en remplaçant « Bonne écoute ! » par « Bienvenue ! » pour un libellé plus explicite.

### Description
- Remplacé le texte du titre `h2` dans `frontend/src/components/Flowbox/Discover.js` de `Bonne écoute !` à `Bienvenue !`.

### Testing
- Vérification automatique effectuée avec `rg -n "Bienvenue !|Bonne écoute !" frontend/src/components/Flowbox/Discover.js` et le fichier a été commité avec `git commit`, les deux commandes ont réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf1c8612c833295b5bad12caba3a7)