### PR TITLE
Harden flowbox location validation and handle expired box sessions in frontend

### DIFF
--- a/box_management/api/views/core.py
+++ b/box_management/api/views/core.py
@@ -1,4 +1,5 @@
 # ===== Standard library =====
+import math
 import re
 from urllib.parse import quote
 
@@ -453,6 +454,15 @@ class Location(APIView):
             latitude = float(request.data.get("latitude"))
             longitude = float(request.data.get("longitude"))
         except (TypeError, ValueError):
+            return api_error(status.HTTP_400_BAD_REQUEST, "INVALID_COORDINATES", "Invalid latitude/longitude")
+        if (
+            not math.isfinite(latitude)
+            or not math.isfinite(longitude)
+            or latitude < -90
+            or latitude > 90
+            or longitude < -180
+            or longitude > 180
+        ):
             return api_error(status.HTTP_400_BAD_REQUEST, "INVALID_COORDINATES", "Invalid latitude/longitude")
 
         result, error = verify_location_for_box(

--- a/frontend/src/components/Common/Article/ArticleDrawer.js
+++ b/frontend/src/components/Common/Article/ArticleDrawer.js
@@ -4,11 +4,15 @@ import Button from "@mui/material/Button";
 import CircularProgress from "@mui/material/CircularProgress";
 import Drawer from "@mui/material/Drawer";
 import Typography from "@mui/material/Typography";
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
+import { FlowboxSessionContext } from "../../Flowbox/runtime/FlowboxSessionContext";
 import MarkdownContent from "../../Utils/MarkdownContent";
 
 export default function ArticleDrawer({ article, open, onClose, boxSlug }) {
+  const navigate = useNavigate();
+  const { clearBoxSession } = useContext(FlowboxSessionContext);
   const previewText = typeof article?.short_text === "string" ? article.short_text : "";
   const [fullText, setFullText] = useState(previewText);
   const [loadingFullText, setLoadingFullText] = useState(false);
@@ -40,6 +44,11 @@ export default function ArticleDrawer({ article, open, onClose, boxSlug }) {
         const data = await res.json().catch(() => null);
 
         if (!res.ok) {
+          if (res.status === 403 && data?.code === "BOX_SESSION_REQUIRED") {
+            clearBoxSession(boxSlug, { markExpired: true });
+            navigate(`/flowbox/${encodeURIComponent(boxSlug)}/closed`, { replace: true });
+            return;
+          }
           throw new Error(data?.detail || "Impossible de charger l’article.");
         }
 
@@ -60,7 +69,7 @@ export default function ArticleDrawer({ article, open, onClose, boxSlug }) {
     return () => {
       cancelled = true;
     };
-  }, [article?.id, boxSlug, open, previewText]);
+  }, [article?.id, boxSlug, clearBoxSession, navigate, open, previewText]);
 
   return (
     <Drawer

--- a/frontend/src/components/Flowbox/Discover.js
+++ b/frontend/src/components/Flowbox/Discover.js
@@ -35,7 +35,7 @@ export default function Discover() {
   const navigate = useNavigate();
   const { boxSlug } = useParams();
   const { user } = useContext(UserContext) || {};
-  const { getDiscoverSnapshot } = useContext(FlowboxSessionContext);
+  const { getDiscoverSnapshot, clearBoxSession } = useContext(FlowboxSessionContext);
 
   const [boxContent, setBoxContent] = useState(null);
   const [openAchievements, setOpenAchievements] = useState(false);
@@ -68,6 +68,11 @@ export default function Discover() {
         const data = await res.json().catch(() => []);
 
         if (!res.ok) {
+          if (res.status === 403 && data?.code === "BOX_SESSION_REQUIRED") {
+            clearBoxSession(boxSlug, { markExpired: true });
+            navigate(`/flowbox/${encodeURIComponent(boxSlug)}/closed`, { replace: true });
+            return;
+          }
           throw new Error(data?.detail || "Impossible de charger les articles.");
         }
         if (cancelled) {return;}
@@ -83,7 +88,7 @@ export default function Discover() {
     return () => {
       cancelled = true;
     };
-  }, [boxSlug]);
+  }, [boxSlug, clearBoxSession, navigate]);
 
   useEffect(() => {
     const shouldOpenAchievements = matchesDrawerSearch(

--- a/frontend/src/components/Flowbox/LiveSearch.js
+++ b/frontend/src/components/Flowbox/LiveSearch.js
@@ -27,7 +27,7 @@ export default function LiveSearch() {
   const navigate = useNavigate();
   const { boxSlug } = useParams();
   const { user, setUser } = useContext(UserContext) || {};
-  const { getBoxRuntime, saveDiscoverSnapshot } = useContext(FlowboxSessionContext);
+  const { getBoxRuntime, saveDiscoverSnapshot, clearBoxSession } = useContext(FlowboxSessionContext);
 
   const runtime = getBoxRuntime(boxSlug);
   const incitationText = (runtime?.box?.searchIncitationText || "").trim();
@@ -101,6 +101,11 @@ export default function LiveSearch() {
 
         const data = (await response.json().catch(() => null)) || {};
         if (!response.ok) {
+          if (response.status === 403 && data?.code === "BOX_SESSION_REQUIRED") {
+            clearBoxSession(boxSlug, { markExpired: true });
+            navigate(`/flowbox/${encodeURIComponent(boxSlug)}/closed`, { replace: true });
+            return;
+          }
           throw new Error(data?.detail || "Erreur pendant le dépôt");
         }
 
@@ -154,7 +159,7 @@ export default function LiveSearch() {
         goOnboardingWithError(error?.message || "Erreur pendant le dépôt");
       }
     },
-    [boxSlug, depositFlowState.status, goOnboardingWithError, saveDiscoverSnapshot, setUser]
+    [boxSlug, clearBoxSession, depositFlowState.status, goOnboardingWithError, navigate, saveDiscoverSnapshot, setUser]
   );
 
   const handleDepositVisualComplete = useCallback(


### PR DESCRIPTION
### Motivation
- The audit targeted location/session checks for `/flowbox/` and aimed to keep the backend as the source of truth while applying small, local fixes for clear issues. 
- Two concrete problems were identified: backend accepted floatable but invalid coordinates, and the frontend didn’t consistently react when the server declared a session invalid, causing UX/state drift.

### Description
- Reject non-finite or out-of-range coordinates early in `POST /box-management/verify-location` by adding `math.isfinite` and lat/lon bounds checks, returning `INVALID_COORDINATES` (400) when invalid. (`box_management/api/views/core.py`)
- Make frontend behavior consistent when the server responds with `403` + `BOX_SESSION_REQUIRED`: expire the local flowbox session state and redirect to the closed-box page `/flowbox/:boxSlug/closed` instead of silently failing or routing to onboarding. This was applied in the flowbox code paths that fetch or act while in-session: song deposit (`LiveSearch`), article list (`Discover`) and article detail (`ArticleDrawer`). (files changed below)
- Changes are minimal and local, they do not alter API payload shapes or session semantics on the server; frontend reacts to an existing business error code instead of adding client-side authorization logic.

### Testing
- Ran `python manage.py test box_management` which exercised the affected area; the run failed due to pre-existing test/import issues in the repo unrelated to these changes (missing `FlowboxAPITestCase` import and an existing 401/403 expectation mismatch). The failures are not caused by this patch.
- Ran `ruff check .` which reported repository-wide lint issues unrelated to the modified files; `ruff` checks for the modified backend file passed locally (`ruff check box_management/api/views/core.py` returned clean for the change).
- Ran `ruff format --check .` which passed.
- Frontend validations: `cd frontend && npm run lint -- --quiet` failed due to unrelated lint errors in other files, but targeted lint of modified files passed: `cd frontend && npx eslint src/components/Flowbox/LiveSearch.js src/components/Flowbox/Discover.js src/components/Common/Article/ArticleDrawer.js --quiet` succeeded.
- Frontend build `cd frontend && npm run build` succeeded.

Files changed:
- `box_management/api/views/core.py` (validate lat/lon with `math.isfinite` and bounds)
- `frontend/src/components/Flowbox/LiveSearch.js` (handle `BOX_SESSION_REQUIRED` on deposit)
- `frontend/src/components/Flowbox/Discover.js` (handle `BOX_SESSION_REQUIRED` when loading articles)
- `frontend/src/components/Common/Article/ArticleDrawer.js` (handle `BOX_SESSION_REQUIRED` when loading article detail)

Remaining risks / follow-ups (not changed here):
- The repo has pre-existing test and lint debt (global `ruff`/ESLint failures and some failing imports in tests) that prevent a fully-green `python manage.py test` and CI; this should be addressed in a separate cleanup ticket.
- `Onboarding` currently treats all `403` from `verify-location` as proximity failures; if finer UX distinctions are needed, clarify product requirements before changing behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea237d40e08332a47a23d04c0bceac)