### PR TITLE
Add UserInline component and refactor deposit/reaction user displays

### DIFF
--- a/frontend/src/components/Common/Deposit/comments/DepositComments.js
+++ b/frontend/src/components/Common/Deposit/comments/DepositComments.js
@@ -1,7 +1,6 @@
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import LibraryMusicIcon from "@mui/icons-material/LibraryMusic";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
-import Avatar from "@mui/material/Avatar";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
@@ -11,12 +10,12 @@ import MenuItem from "@mui/material/MenuItem";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import React, { useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
 
 import { getCookie } from "../../../Security/TokensUtils";
 import { formatRelativeTime } from "../../../Utils/time";
 import ConfirmActionDialog from "../../ConfirmActionDialog";
 import SearchPanel from "../../Search/SearchPanel";
+import UserInline from "../../UserInline";
 
 const EMPTY_CONTEXT = { items: [], count: 0, viewer_state: {} };
 
@@ -40,8 +39,6 @@ export default function DepositComments({
   boxSx,
   DepositComponent,
 }) {
-  const navigate = useNavigate();
-
   const [context, setContext] = useState(comments || EMPTY_CONTEXT);
   const [draft, setDraft] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -233,35 +230,18 @@ export default function DepositComments({
           ? items.map((comment) => {
             const commentUser = comment?.user || {};
             const hasSongReply = Boolean(comment?.reply_deposit);
-            const canNavigate = Boolean(commentUser?.username && !commentUser?.is_guest);
-
             return (
               <Box key={comment.id} sx={{ mb: 1.5 }}>
                 <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1 }}>
-                  <Avatar
-                    src={commentUser?.profile_picture_url || ""}
-                    alt={commentUser?.display_name || commentUser?.username || "user"}
-                    sx={{ width: 28, height: 28 }}
-                  />
                   <Box sx={{ flex: 1, minWidth: 0 }}>
-                    <Typography variant="subtitle2" component="div">
-                      <Box
-                        component="span"
-                        sx={{
-                          cursor: canNavigate ? "pointer" : "default",
-                          textDecoration: canNavigate ? "underline" : "none",
-                        }}
-                        onClick={() => {
-                          if (!canNavigate) {return;}
-                          navigate(`/profile/${commentUser.username}`);
-                        }}
-                      >
-                        {commentUser?.display_name || commentUser?.username || "anonyme"}
+                    <Box sx={{ display: "flex", alignItems: "center", minWidth: 0, gap: 1 }}>
+                      <Box sx={{ minWidth: 0, flex: 1 }}>
+                        <UserInline user={commentUser} avatarSize={28} />
                       </Box>
-                      <Typography component="span" variant="caption" sx={{ ml: 1, opacity: 0.7 }}>
+                      <Typography component="span" variant="caption" sx={{ opacity: 0.7, whiteSpace: "nowrap", flex: "0 0 auto" }}>
                         {comment?.created_at ? formatRelativeTime(comment.created_at) : ""}
                       </Typography>
-                    </Typography>
+                    </Box>
 
                     {comment?.text ? (
                       <Typography variant="body2" sx={{ whiteSpace: "pre-wrap", mt: 0.5 }}>

--- a/frontend/src/components/Common/Deposit/parts/DepositUser.js
+++ b/frontend/src/components/Common/Deposit/parts/DepositUser.js
@@ -1,35 +1,15 @@
-import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
-import Avatar from "@mui/material/Avatar";
-import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
 import React from "react";
 
-export default function DepositUser({ user, userPrefix = "Partagée par", onNavigateProfile }) {
-  const canNavigate = Boolean(user?.username && !user?.is_guest);
+import UserInline from "../../UserInline";
 
+export default function DepositUser({ user, userPrefix = "Partagée par", onNavigateProfile }) {
   return (
-    <Box
-      onClick={() => {
-        if (canNavigate) {onNavigateProfile?.(user.username);}
-      }}
-      className={canNavigate ? "hasUsername deposit_user" : "deposit_user"}
-    >
-      <Typography variant="body1" component="span">
-        {userPrefix}
-      </Typography>
-      <Box className="avatarbox">
-        <Avatar
-          src={user?.profile_picture_url || undefined}
-          alt={user?.display_name || "anonyme"}
-          className="avatar"
-        />
-      </Box>
-      <Typography component="span" className="username" variant="subtitle1">
-        {user?.display_name || "anonyme"}
-        {canNavigate ? (
-          <ArrowForwardIosIcon className="icon" sx={{ height: "0.8em", width: "0.8em" }} />
-        ) : null}
-      </Typography>
-    </Box>
+    <UserInline
+      user={user}
+      prefix={userPrefix}
+      className="deposit_user"
+      onNavigateProfile={onNavigateProfile}
+      avatarSize={26}
+    />
   );
 }

--- a/frontend/src/components/Common/Deposit/reactions/ReactionSummary.js
+++ b/frontend/src/components/Common/Deposit/reactions/ReactionSummary.js
@@ -1,6 +1,4 @@
-import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 import Alert from "@mui/material/Alert";
-import Avatar from "@mui/material/Avatar";
 import Box from "@mui/material/Box";
 import Drawer from "@mui/material/Drawer";
 import Typography from "@mui/material/Typography";
@@ -8,6 +6,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { getCookie } from "../../../Security/TokensUtils";
+import UserInline from "../../UserInline";
 
 function normalizeReactionUser(rawUser = {}) {
   const isGuest = Boolean(rawUser?.is_guest);
@@ -105,32 +104,9 @@ export default function ReactionSummary({
   const renderReactionRow = (reaction, index) => {
     const normalized = normalizeReactionUser(reaction?.user || {});
     const isMine = Boolean(viewerId && normalized.id === viewerId);
-    const canNavigate = !isMine && !normalized.isGuest && Boolean(normalized.username);
-
-    const handleClick = () => {
-      if (isMine) {
-        handleDeleteOwnReaction();
-        return;
-      }
-
-      if (!canNavigate) {return;}
-
-      onClose?.({ replace: true });
-      navigate("/profile/" + normalized.username);
-    };
-
     return (
       <Box
         key={`${reaction?.emoji || "emoji"}-${normalized.id || normalized.username || index}`}
-        onClick={handleClick}
-        role={isMine || canNavigate ? "button" : undefined}
-        tabIndex={isMine || canNavigate ? 0 : -1}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            handleClick();
-          }
-        }}
         className={normalized?.username ? "hasUsername reaction" : "reaction"}
         sx={{
           py: 1.25,
@@ -144,25 +120,21 @@ export default function ReactionSummary({
           {reaction?.emoji}
         </Typography>
 
-        <Box className="avatarbox">
-          <Avatar
-            src={normalized?.profile_picture_url || undefined}
-            alt={normalized?.displayName || "anonyme"}
-            className="avatar"
+        <Box className="texts" sx={{ minWidth: 0, flex: 1 }}>
+          <UserInline
+            user={{
+              username: normalized?.username,
+              display_name: normalized?.displayName,
+              profile_picture_url: normalized?.profile_picture_url,
+              is_guest: normalized?.isGuest,
+            }}
+            subtitle={isMine ? "tape ici pour supprimer ta réaction" : ""}
+            onClick={isMine ? handleDeleteOwnReaction : undefined}
+            onNavigateProfile={(username) => {
+              onClose?.({ replace: true });
+              navigate(`/profile/${username}`);
+            }}
           />
-        </Box>
-
-        <Box className="texts">
-          <Typography component="span" className="username" variant="subtitle1">
-            {normalized?.displayName || "anonyme"}
-            {canNavigate && <ArrowForwardIosIcon className="icon" />}
-          </Typography>
-
-          {isMine && (
-            <Typography variant="body2" className="click_delete">
-              tape ici pour supprimer ta réaction
-            </Typography>
-          )}
         </Box>
       </Box>
     );

--- a/frontend/src/components/Common/UserInline.js
+++ b/frontend/src/components/Common/UserInline.js
@@ -1,0 +1,125 @@
+import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
+import Avatar from "@mui/material/Avatar";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+function UserInline({
+  user,
+  subtitle,
+  onClick,
+  onNavigateProfile,
+  prefix,
+  className = "",
+  avatarSize = 26,
+}) {
+  const navigate = useNavigate();
+
+  const username = (user?.username || "").trim();
+  const displayName = (user?.display_name || user?.displayName || username || "anonyme").trim() || "anonyme";
+  const canAutoNavigate = !onClick && Boolean(username && !user?.is_guest);
+  const hasAction = Boolean(onClick || canAutoNavigate);
+  const trimmedSubtitle = typeof subtitle === "string" ? subtitle.trim() : "";
+
+  const handleClick = () => {
+    if (onClick) {
+      onClick();
+      return;
+    }
+
+    if (!canAutoNavigate) {return;}
+
+    if (onNavigateProfile) {
+      onNavigateProfile(username);
+      return;
+    }
+
+    navigate(`/profile/${username}`);
+  };
+
+  return (
+    <Box
+      component="button"
+      type="button"
+      onClick={handleClick}
+      className={`${username ? "hasUsername " : ""}${className}`.trim() || undefined}
+      sx={{
+        all: "unset",
+        boxSizing: "border-box",
+        display: "flex",
+        alignItems: "center",
+        gap: "6px",
+        width: "100%",
+        maxWidth: "100%",
+        minWidth: 0,
+        cursor: hasAction ? "pointer" : "default",
+        "&:active": hasAction ? { opacity: 0.92 } : undefined,
+      }}
+    >
+      {prefix ? (
+        <Typography variant="body1" component="span" sx={{ flex: "0 0 auto", whiteSpace: "nowrap" }}>
+          {prefix}
+        </Typography>
+      ) : null}
+
+      <Box className="avatarbox" sx={{ flex: "0 0 auto" }}>
+        <Avatar
+          src={user?.profile_picture_url || undefined}
+          alt={displayName}
+          className="avatar"
+          sx={{ width: avatarSize, height: avatarSize }}
+        />
+      </Box>
+
+      <Box sx={{ minWidth: 0, flex: "1 1 auto", maxWidth: "100%" }}>
+        <Typography
+          component="span"
+          className="username"
+          variant="subtitle1"
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: "4px",
+            minWidth: 0,
+            maxWidth: "100%",
+            whiteSpace: "nowrap",
+          }}
+        >
+          <Box
+            component="span"
+            sx={{
+              display: "block",
+              minWidth: 0,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {displayName}
+          </Box>
+          {canAutoNavigate ? <ArrowForwardIosIcon className="icon" sx={{ height: "0.8em", width: "0.8em", flex: "0 0 auto" }} /> : null}
+        </Typography>
+
+        {trimmedSubtitle ? (
+          <Typography
+            variant="body2"
+            className="click_delete"
+            sx={{
+              opacity: "var(--mm-opacity-light-text)",
+              minWidth: 0,
+              maxWidth: "100%",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {trimmedSubtitle}
+          </Typography>
+        ) : null}
+      </Box>
+    </Box>
+  );
+}
+
+export default React.memo(UserInline);


### PR DESCRIPTION
### Motivation
- Standardize user avatar/label presentation across deposit comments, deposit header, and reaction summaries to reduce duplication and centralize navigation behavior.
- Replace ad-hoc avatar/username handling with a single reusable component that consistently handles avatar size, click/navigation, and subtitle text.

### Description
- Add new `UserInline` component at `frontend/src/components/Common/UserInline.js` that renders an avatar, display name, optional prefix and subtitle, and handles navigation via `onNavigateProfile` or internal `useNavigate`; it accepts `avatarSize`, `prefix`, `subtitle`, `onClick`, and `className` props.
- Replace inline avatar/username markup in `DepositComments.js` with `UserInline` and remove direct `useNavigate` usage and duplicated click/keyboard handlers there.
- Replace the old `DepositUser` implementation with a thin wrapper around `UserInline` in `Deposit/parts/DepositUser.js` to reuse the common UI and behavior.
- Refactor `ReactionSummary.js` to use `UserInline` for each reaction row, wire `onClick` to delete the user's own reaction, and wire profile navigation via `onNavigateProfile` while keeping the emoji layout intact.
- Remove several now-unused imports (`Avatar`, component-level `useNavigate`, etc.) and adapt normalized user shapes to the `UserInline` prop expectations.

### Testing
- Ran frontend unit tests via `yarn test` and component tests; all tests completed successfully.
- Ran linting via `yarn lint` with no new lint errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea581d8c5883328842da7edef08f8d)