### PR TITLE
Remove re-export stubs for components and backend article fetch, update tests to import implementations directly

### DIFF
--- a/box_management/services/articles/fetch_article_content.py
+++ b/box_management/services/articles/fetch_article_content.py
@@ -1,3 +1,0 @@
-from box_management.integrations.article_scraper import _extract_import_preview_from_url
-
-__all__ = ["_extract_import_preview_from_url"]

--- a/frontend/src/components/Comments/CommentsDrawer.js
+++ b/frontend/src/components/Comments/CommentsDrawer.js
@@ -1,1 +1,0 @@
-export { default } from "../Common/Deposit/comments/DepositComments";

--- a/frontend/src/components/Reactions/AddReactionModal.js
+++ b/frontend/src/components/Reactions/AddReactionModal.js
@@ -1,1 +1,0 @@
-export { default } from "../Common/Deposit/reactions/DepositReactions";

--- a/frontend/src/components/Reactions/AddReactionModal.test.js
+++ b/frontend/src/components/Reactions/AddReactionModal.test.js
@@ -1,10 +1,9 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
+import AddReactionModal from '../Common/Deposit/reactions/DepositReactions';
 import { UserContext } from '../UserContext';
-
-import AddReactionModal from './AddReactionModal';
 
 jest.mock('../Security/TokensUtils', () => ({
   getCookie: jest.fn(() => 'csrftoken'),

--- a/frontend/src/components/Reactions/ReactionSummary.js
+++ b/frontend/src/components/Reactions/ReactionSummary.js
@@ -1,1 +1,0 @@
-export { default } from "../Common/Deposit/reactions/ReactionSummary";


### PR DESCRIPTION
### Motivation
- Remove thin re-export wrapper files that duplicate component/back-end entry points and consolidate imports to the actual implementation paths.
- Point tests at the real component implementation to avoid indirection and remove an unused test helper import.
- Remove an obsolete backend re-export for the article scraper to reduce dead code.

### Description
- Deleted frontend re-export files `frontend/src/components/Comments/CommentsDrawer.js`, `frontend/src/components/Reactions/AddReactionModal.js`, and `frontend/src/components/Reactions/ReactionSummary.js` so callers should import the components from their canonical locations.
- Deleted backend re-export `box_management/services/articles/fetch_article_content.py` that only forwarded `_extract_import_preview_from_url`.
- Updated `frontend/src/components/Reactions/AddReactionModal.test.js` to import `AddReactionModal` from `../Common/Deposit/reactions/DepositReactions` instead of the removed local stub and removed the unused `waitFor` import.

### Testing
- Ran the updated test file with `yarn test AddReactionModal.test.js` and the test completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea850bb84c83329bc133d8671a6840)