### PR TITLE
Ajoute l'option `--errors` à la commande `seed_activity`

### DIFF
--- a/box_management/management/commands/seed_activity.py
+++ b/box_management/management/commands/seed_activity.py
@@ -22,6 +22,11 @@ class Command(BaseCommand):
         )
         parser.add_argument("--seed", type=int, default=None, help="Seed aléatoire pour un run reproductible.")
         parser.add_argument("--dry-run", action="store_true", help="Affiche la cible sans écrire en base.")
+        parser.add_argument(
+            "--errors",
+            action="store_true",
+            help="Affiche les erreurs détaillées (avec traceback) au lieu d'un message simplifié.",
+        )
 
     def handle(self, *args, **options):
         days = int(options["days"])
@@ -37,6 +42,8 @@ class Command(BaseCommand):
                 dry_run=bool(options.get("dry_run")),
             )
         except ValueError as exc:
+            if options.get("errors"):
+                raise
             raise CommandError(str(exc)) from exc
 
         if status == "dry_run":


### PR DESCRIPTION
### Motivation
- Permettre d'afficher des erreurs détaillées (traceback) lors de l'exécution du script de seed pour faciliter le débogage lorsque nécessaire.
- Conserver le comportement actuel (message simplifié via `CommandError`) par défaut pour ne pas inonder les runs normaux.

### Description
- Ajout de l'argument CLI `--errors` dans `box_management/management/commands/seed_activity.py` avec l'aide indiquant qu'il affiche les erreurs détaillées (traceback). 
- Lors de la capture de `ValueError`, la commande relaie l'exception brute si `options.get("errors")` est vrai, sinon elle convertit l'erreur en `CommandError` comme avant.
- Le comportement existant est préservé par défaut et l'aide de la commande (`--help`) expose le nouveau flag.

### Testing
- Exécution de `python manage.py seed_activity --help` pour valider l'ajout du flag `--errors`, la sortie contient bien l'option et la description attendue (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb78813d908332ab025a6c5c8de29e)