### PR TITLE
Allow commenting and reacting on box/pinned deposits without an active box session

### DIFF
--- a/box_management/services/comments/create_comment.py
+++ b/box_management/services/comments/create_comment.py
@@ -17,7 +17,6 @@ from box_management.domain.constants import (
     COMMENT_TARGET_USER_DAILY_LIMIT,
 )
 from box_management.models import Comment, CommentModerationDecision, Deposit
-from box_management.selectors.boxes import get_active_box_session
 from box_management.selectors.deposits import get_deposit_for_comment
 from box_management.services.comments.moderation_rules import (
     _detect_comment_pre_creation_error,
@@ -42,14 +41,6 @@ def create_comment(*, user, dep_public_key, text_value, song_option, author_ip, 
     deposit = get_deposit_for_comment(dep_public_key)
     if not deposit:
         return None, {"status": status.HTTP_404_NOT_FOUND, "code": "DEPOSIT_NOT_FOUND", "detail": "Dépôt introuvable."}
-
-    if getattr(deposit, "box", None) and getattr(deposit, "deposit_type", "box") != "favorite":
-        if not get_active_box_session(user, deposit.box):
-            return None, {
-                "status": status.HTTP_403_FORBIDDEN,
-                "code": "BOX_SESSION_REQUIRED",
-                "detail": "Ouvre la boîte pour continuer.",
-            }
 
     client = getattr(getattr(deposit, "box", None), "client", None)
     if not client and getattr(deposit, "deposit_type", "box") != "favorite":

--- a/box_management/services/reactions/add_reaction.py
+++ b/box_management/services/reactions/add_reaction.py
@@ -2,7 +2,6 @@ from django.db import transaction
 from rest_framework import status
 
 from box_management.models import Deposit, DiscoveredSong, Emoji, EmojiRight, Reaction
-from box_management.selectors.boxes import get_active_box_session
 from box_management.selectors.deposits import get_deposit_for_reaction, get_deposit_with_reactions
 from users.models import CustomUser
 
@@ -11,21 +10,6 @@ def add_or_remove_reaction(*, user, dep_public_key, emoji_id):
     deposit = get_deposit_for_reaction(dep_public_key)
     if not deposit:
         return None, {"status": status.HTTP_404_NOT_FOUND, "code": "DEPOSIT_NOT_FOUND", "detail": "Dépôt introuvable"}
-
-    if (
-        getattr(deposit, "box", None)
-        and getattr(deposit, "deposit_type", Deposit.DEPOSIT_TYPE_BOX)
-        in (
-            Deposit.DEPOSIT_TYPE_BOX,
-            Deposit.DEPOSIT_TYPE_PINNED,
-        )
-        and not get_active_box_session(user, deposit.box)
-    ):
-        return None, {
-            "status": status.HTTP_403_FORBIDDEN,
-            "code": "BOX_SESSION_REQUIRED",
-            "detail": "Ouvre la boîte pour continuer.",
-        }
 
     is_revealed_for_user = bool(
         getattr(deposit, "user_id", None) == getattr(user, "id", None)

--- a/box_management/tests/test_double_actions.py
+++ b/box_management/tests/test_double_actions.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from box_management.models import (
+    BoxSession,
     Comment,
     CommentModerationDecision,
     Deposit,
@@ -311,3 +312,55 @@ class CommentAndShareDoubleActionTests(FlowboxAPITestCase):
         comments = visible.data["comments"]
         self.assertEqual(comments["count"], 1)
         self.assertEqual(len(comments["items"]), 1)
+
+    def test_comment_on_box_deposit_without_active_box_session_is_allowed(self):
+        user = self.auth(self.make_user(username="comment-no-session", points=0))
+        BoxSession.objects.filter(user=user, box=self.box).delete()
+
+        response = self.client.post(
+            reverse("comments-create"),
+            {"dep_public_key": self.deposit.public_key, "text": "hors session"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(Comment.objects.filter(user=user, deposit=self.deposit, text="hors session").exists())
+
+    def test_comment_on_pinned_deposit_without_active_box_session_is_allowed(self):
+        user = self.auth(self.make_user(username="comment-pinned-no-session", points=0))
+        pinned = self.make_deposit(
+            user=self.owner,
+            song=self.make_song(public_key="comment-pinned-song"),
+            box=self.box,
+            deposit_type=Deposit.DEPOSIT_TYPE_PINNED,
+            pin_duration_minutes=10,
+            pin_points_spent=149,
+            pin_expires_at=timezone.now() + timedelta(minutes=10),
+        )
+        BoxSession.objects.filter(user=user, box=self.box).delete()
+
+        response = self.client.post(
+            reverse("comments-create"),
+            {"dep_public_key": pinned.public_key, "text": "comment pinned hors session"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(Comment.objects.filter(user=user, deposit=pinned).exists())
+
+    def test_comment_requires_authentication(self):
+        response = self.client.post(
+            reverse("comments-create"),
+            {"dep_public_key": self.deposit.public_key, "text": "sans auth"},
+            format="json",
+        )
+        self.assert_api_error(response, 401, "AUTH_REQUIRED")
+
+    def test_comment_empty_content_is_rejected(self):
+        self.auth(self.make_user(username="comment-empty", points=0))
+        response = self.client.post(
+            reverse("comments-create"),
+            {"dep_public_key": self.deposit.public_key, "text": "   "},
+            format="json",
+        )
+        self.assert_api_error(response, 400, "COMMENT_EMPTY")

--- a/box_management/tests/test_points_flows.py
+++ b/box_management/tests/test_points_flows.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from django.urls import reverse
 from django.utils import timezone
 
-from box_management.models import Deposit, DiscoveredSong, EmojiRight, Reaction
+from box_management.models import BoxSession, Deposit, DiscoveredSong, EmojiRight, Reaction
 from box_management.tests.base import FlowboxAPITestCase
 from la_boite_a_son.economy import (
     COST_REVEAL_BOX,
@@ -383,6 +383,42 @@ class EmojiPurchaseAndReactionFlowTests(FlowboxAPITestCase):
         response = self.client.get(reverse("emoji-catalog"), {"dep_public_key": deposit.public_key})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["current_reaction"]["id"], emoji.id)
+
+    def test_reaction_on_box_deposit_without_active_box_session_is_allowed(self):
+        user = self.auth(self.make_user(username="react-no-session", points=500))
+        emoji = self.make_emoji(char="🔥", cost=0)
+        box = self.make_box(url="box-react-no-session", name="Box react no session")
+        deposit = self.make_deposit(user=user, song=self.make_song(public_key="react_song_no_session"), box=box)
+        BoxSession.objects.filter(user=user, box=box).delete()
+
+        response = self.client.post(
+            reverse("reactions"), {"dep_public_key": deposit.public_key, "emoji_id": emoji.id}, format="json"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Reaction.objects.filter(user=user, deposit=deposit, emoji=emoji).count(), 1)
+
+    def test_reaction_on_pinned_deposit_without_active_box_session_is_allowed(self):
+        user = self.auth(self.make_user(username="react-pinned-no-session", points=500))
+        emoji = self.make_emoji(char="🔥", cost=0)
+        box = self.make_box(url="box-react-pinned-no-session", name="Box react pinned no session")
+        pinned = self.make_deposit(
+            user=self.make_user(username="owner-react-pinned"),
+            song=self.make_song(public_key="react_song_pinned_no_session"),
+            box=box,
+            deposit_type=Deposit.DEPOSIT_TYPE_PINNED,
+            pin_duration_minutes=10,
+            pin_points_spent=149,
+            pin_expires_at=timezone.now() + timedelta(minutes=10),
+        )
+        BoxSession.objects.filter(user=user, box=box).delete()
+
+        response = self.client.post(
+            reverse("reactions"), {"dep_public_key": pinned.public_key, "emoji_id": emoji.id}, format="json"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Reaction.objects.filter(user=user, deposit=pinned, emoji=emoji).count(), 1)
 
 
 class DepositPointsFlowTests(FlowboxAPITestCase):


### PR DESCRIPTION
### Motivation

- Remove the requirement for an active box session when creating comments or adding reactions on box and pinned deposits so that revealed content can be interacted with even if the user has no active session.

### Description

- Remove `get_active_box_session` import and the active-session gating logic from `box_management/services/comments/create_comment.py` so comments on box and pinned deposits are allowed without a session.
- Remove `get_active_box_session` import and the active-session gating logic from `box_management/services/reactions/add_reaction.py` so reactions on box and pinned deposits are allowed without a session.
- Update tests to import `BoxSession` and add tests that assert commenting and reacting without an active box session is allowed for both box and pinned deposits.

### Testing

- Ran the `box_management` test suite (Django tests) including the newly added tests and the existing flows; all tests passed.
- New tests executed include `test_comment_on_box_deposit_without_active_box_session_is_allowed`, `test_comment_on_pinned_deposit_without_active_box_session_is_allowed`, `test_reaction_on_box_deposit_without_active_box_session_is_allowed`, and `test_reaction_on_pinned_deposit_without_active_box_session_is_allowed`, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0623d6648332a72bf58cfae29369)