### PR TITLE
Replace song search dialog with history-aware drawer and block consecutive replies in DepositComments

### DIFF
--- a/frontend/src/components/Common/Deposit/comments/DepositComments.js
+++ b/frontend/src/components/Common/Deposit/comments/DepositComments.js
@@ -1,23 +1,35 @@
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
+import Alert from "@mui/material/Alert";
 import LibraryMusicIcon from "@mui/icons-material/LibraryMusic";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import Drawer from "@mui/material/Drawer";
 import IconButton from "@mui/material/IconButton";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { getCookie } from "../../../Security/TokensUtils";
+import {
+  closeDrawerWithHistory,
+  matchesDrawerSearch,
+  openDrawerWithHistory,
+} from "../../../Utils/drawerHistory";
 import { formatRelativeTime } from "../../../Utils/time";
 import ConfirmActionDialog from "../../ConfirmActionDialog";
 import SearchPanel from "../../Search/SearchPanel";
 import UserInline from "../../UserInline";
 
 const EMPTY_CONTEXT = { items: [], count: 0, viewer_state: {} };
+const COMMENT_SONG_DRAWER_PARAM = "commentDrawer";
 
 function buildSongFromOption(option) {
   const artists = Array.isArray(option?.artists) ? option.artists.filter(Boolean) : [];
@@ -39,6 +51,8 @@ export default function DepositComments({
   boxSx,
   DepositComponent,
 }) {
+  const navigate = useNavigate();
+  const location = useLocation();
   const [context, setContext] = useState(comments || EMPTY_CONTEXT);
   const [draft, setDraft] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -50,8 +64,9 @@ export default function DepositComments({
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [reporting, setReporting] = useState(false);
-  const [searchOpen, setSearchOpen] = useState(false);
+  const [songDrawerOpen, setSongDrawerOpen] = useState(false);
   const [selectedSongOption, setSelectedSongOption] = useState(null);
+  const [isConsecutiveReplyDialogOpen, setIsConsecutiveReplyDialogOpen] = useState(false);
 
   useEffect(() => {
     setContext(comments || EMPTY_CONTEXT);
@@ -63,6 +78,14 @@ export default function DepositComments({
   const isFullUser = Boolean(viewer?.id && !viewer?.is_guest);
   const canPost = Boolean(isFullUser && viewerState?.can_post);
   const notice = viewerState?.notice || "";
+  const isConsecutiveReplyBlocked = Boolean(
+    isFullUser && !canPost && notice.toLowerCase().includes("deux réponses"),
+  );
+  const inlineNotice = isConsecutiveReplyBlocked ? "" : notice;
+  const commentSongDrawerValue = useMemo(
+    () => `song-reply-${depPublicKey || "unknown"}`,
+    [depPublicKey],
+  );
 
   const selectedSongPreviewDep = useMemo(() => {
     if (!selectedSongOption) {return null;}
@@ -107,13 +130,62 @@ export default function DepositComments({
     loadReplies();
   }, [depPublicKey, hasLoaded, isParentRevealed, loadingReplies, onCommentsChange, open]);
 
+  useEffect(() => {
+    const shouldOpenDrawer = matchesDrawerSearch(
+      location,
+      COMMENT_SONG_DRAWER_PARAM,
+      commentSongDrawerValue,
+    );
+
+    if (shouldOpenDrawer) {
+      setSongDrawerOpen((prev) => (prev ? prev : true));
+      return;
+    }
+
+    setSongDrawerOpen(false);
+  }, [commentSongDrawerValue, location]);
+
   const closeMenu = () => {
     setMenuAnchorEl(null);
     setActiveComment(null);
   };
 
+  const closeSongDrawer = useCallback((options = {}) => {
+    if (
+      closeDrawerWithHistory({
+        navigate,
+        location,
+        param: COMMENT_SONG_DRAWER_PARAM,
+        value: commentSongDrawerValue,
+        replace: Boolean(options?.replace),
+      })
+    ) {
+      return;
+    }
+
+    setSongDrawerOpen(false);
+  }, [commentSongDrawerValue, location, navigate]);
+
+  const openSongDrawer = useCallback(() => {
+    if (isConsecutiveReplyBlocked) {
+      setIsConsecutiveReplyDialogOpen(true);
+      return;
+    }
+
+    openDrawerWithHistory({
+      navigate,
+      location,
+      param: COMMENT_SONG_DRAWER_PARAM,
+      value: commentSongDrawerValue,
+    });
+  }, [commentSongDrawerValue, isConsecutiveReplyBlocked, location, navigate]);
+
   const submitReply = async () => {
     if (submitting) {return;}
+    if (isConsecutiveReplyBlocked) {
+      setIsConsecutiveReplyDialogOpen(true);
+      return;
+    }
 
     const nextText = (draft || "").trim();
     if (!nextText && !selectedSongOption) {
@@ -215,15 +287,20 @@ export default function DepositComments({
 
   if (!open) {return null;}
 
+  const handleBlockedComposerInteraction = () => {
+    if (!isConsecutiveReplyBlocked) {return;}
+    setIsConsecutiveReplyDialogOpen(true);
+  };
+
   return (
     <Box sx={boxSx}>
       <Box sx={{ borderLeft: "2px solid rgba(255,255,255,0.12)", pl: 2 }}>
         {loadingReplies ? <Typography variant="body2">Chargement des réponses…</Typography> : null}
 
         {!loadingReplies && count === 0 ? (
-          <Typography variant="body2" sx={{ py: 1.5 }}>
+          <Alert severity="info" sx={{ my: 1.5 }}>
             Aucune réponse pour l’instant.
-          </Typography>
+          </Alert>
         ) : null}
 
         {!loadingReplies
@@ -279,7 +356,7 @@ export default function DepositComments({
           })
           : null}
 
-        {notice ? <Typography variant="body2" sx={{ mb: 1 }}>{notice}</Typography> : null}
+        {inlineNotice ? <Typography variant="body2" sx={{ mb: 1 }}>{inlineNotice}</Typography> : null}
         {error ? <Typography variant="body2" color="error" sx={{ mb: 1 }}>{error}</Typography> : null}
 
         {selectedSongPreviewDep && DepositComponent ? (
@@ -294,14 +371,14 @@ export default function DepositComments({
               showCommentAction={false}
             />
             <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: 0.5 }}>
-              <Button size="small" onClick={() => setSearchOpen(true)}>Remplacer</Button>
+              <Button size="small" onClick={openSongDrawer}>Remplacer</Button>
               <Button size="small" color="inherit" onClick={() => setSelectedSongOption(null)}>Retirer</Button>
             </Box>
           </Box>
         ) : null}
 
         <Box sx={{ display: "flex", gap: 1, alignItems: "flex-end" }}>
-          <IconButton onClick={() => setSearchOpen(true)} aria-label="Ajouter une chanson">
+          <IconButton onClick={openSongDrawer} aria-label="Ajouter une chanson">
             <LibraryMusicIcon />
           </IconButton>
           <TextField
@@ -310,17 +387,21 @@ export default function DepositComments({
             minRows={1}
             maxRows={5}
             value={draft}
+            onClick={handleBlockedComposerInteraction}
+            onFocus={handleBlockedComposerInteraction}
             onChange={(event) => {
+              if (isConsecutiveReplyBlocked) {return;}
               const nextValue = event.target.value || "";
               if (nextValue.length <= 100) {
                 setDraft(nextValue);
               }
             }}
             label="Répondre"
+            inputProps={{ readOnly: isConsecutiveReplyBlocked }}
           />
           <IconButton
             onClick={submitReply}
-            disabled={!canPost || submitting || (!draft.trim() && !selectedSongOption)}
+            disabled={(!canPost && !isConsecutiveReplyBlocked) || submitting || (!draft.trim() && !selectedSongOption)}
             aria-label="Publier la réponse"
           >
             <ArrowUpwardIcon />
@@ -365,16 +446,56 @@ export default function DepositComments({
         loading={deleting}
       />
 
-      <Dialog open={searchOpen} onClose={() => setSearchOpen(false)} fullWidth maxWidth="md">
-        <Box sx={{ p: 2, height: "70vh" }}>
-          <SearchPanel
-            onSelectSong={(option) => {
-              setSelectedSongOption(option || null);
-              setSearchOpen(false);
-            }}
-            actionLabel="Choisir"
-          />
+      <Drawer
+        anchor="right"
+        open={songDrawerOpen}
+        onClose={() => closeSongDrawer()}
+        PaperProps={{
+          sx: {
+            width: "100vw",
+            maxWidth: "100vw",
+            height: "100vh",
+            overflow: "hidden",
+          },
+        }}
+      >
+        <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
+          <Box sx={{ p: 5, pb: 2 }}>
+            <Typography component="h2" variant="h3" sx={{ mb: 3 }}>
+              Attacher une chanson
+            </Typography>
+          </Box>
+
+          {songDrawerOpen ? (
+            <SearchPanel
+              onSelectSong={(option) => {
+                setSelectedSongOption(option || null);
+                closeSongDrawer({ replace: true });
+              }}
+              actionLabel="Choisir"
+              rootSx={{ flex: 1, minHeight: 0 }}
+              searchBarWrapperSx={{ px: 5, pb: 2 }}
+              contentSx={{ overflowX: "hidden", overflowY: "scroll", flex: 1, pb: "96px" }}
+            />
+          ) : null}
+
+          <Button variant="contained" onClick={() => closeSongDrawer()} className="bottom_fixed">
+            Fermer
+          </Button>
         </Box>
+      </Drawer>
+
+      <Dialog
+        open={isConsecutiveReplyDialogOpen}
+        onClose={() => setIsConsecutiveReplyDialogOpen(false)}
+        fullWidth
+        maxWidth="xs"
+      >
+        <DialogTitle>Réponse indisponible</DialogTitle>
+        <DialogContent>Tu ne peux pas envoyer deux réponses d’affilé</DialogContent>
+        <DialogActions>
+          <Button onClick={() => setIsConsecutiveReplyDialogOpen(false)}>J’ai compris</Button>
+        </DialogActions>
       </Dialog>
     </Box>
   );


### PR DESCRIPTION
### Motivation
- Replace the modal song search UI with a full-height, history-managed drawer to allow direct linking and better UX on mobile.  
- Prevent users from posting two consecutive replies by blocking the composer and surfacing a clear dialog when blocked.  
- Wire drawer open/close state to the URL so the drawer can be opened via navigation/history and closed with history-aware actions.

### Description
- Replaced the `Dialog`-based search UI with a right-side `Drawer` that uses `openDrawerWithHistory`/`closeDrawerWithHistory` and URL param `commentDrawer` to manage history-aware opening and closing.  
- Added `useNavigate` and `useLocation` usage and logic to auto-open the drawer when the URL matches the drawer param via `matchesDrawerSearch`.  
- Introduced consecutive-reply blocking: composer is made read-only, submit and song-attach actions open a `Dialog` explaining the restriction, and a flag `isConsecutiveReplyBlocked` is derived from the viewer notice.  
- Misc UI and behavior tweaks including: replacing empty-list text with an `Alert`, using `Dialog`/`DialogTitle`/`DialogContent`/`DialogActions` for the consecutive-reply modal, guarding input change when blocked, and ensuring selected song preview integrates with the new drawer flow.

### Testing
- Ran frontend unit tests with `yarn test` and component tests locally, and they passed.  
- Ran lint checks with `yarn lint` and fixed issues flagged by the linter.  
- Verified a local dev build with `yarn build` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee1e87acf48332abd4642c0ef1e741)