### PR TITLE
Simplify session timer color states in Menu header

### DIFF
--- a/frontend/src/components/Common/Menu.js
+++ b/frontend/src/components/Common/Menu.js
@@ -39,13 +39,10 @@ function formatLongRemaining(remainingMs) {
 }
 
 function getSessionTone(remainingMs) {
-  if (remainingMs <= ERROR_THRESHOLD_MS) {
-    return { color: "error.main", bg: "error.main" };
-  }
-  if (remainingMs <= WARNING_THRESHOLD_MS) {
+  if (remainingMs < ERROR_THRESHOLD_MS) {
     return { color: "warning.main", bg: "warning.main" };
   }
-  return { color: "success.main", bg: "success.main" };
+  return { color: "primary.main", bg: "primary.main" };
 }
 
 export default function MenuAppBar() {


### PR DESCRIPTION
### Motivation
- Réduire la logique couleur du timer de session à 2 états (normal / warning) pour correspondre au besoin produit et simplifier le rendu visuel. 
- S’assurer que le texte du temps restant et la barre de progression partagent la même source de vérité pour la couleur. 
- Ne pas toucher à la mécanique de session, aux timings, ni à l’expansion UI (le seuil 3 minutes reste disponible pour l’auto-expansion). 

### Description
- Remplacé la logique de `getSessionTone` dans `frontend/src/components/Common/Menu.js` pour n’utiliser que deux états : `primary.main` quand `remainingMs >= 60_000` et `warning.main` quand `remainingMs < 60_000`.
- Supprimé l’usage précédent de l’état intermédiaire (`success.main`) et de `error.main` pour cette logique d’affichage couleur; le `WARNING_THRESHOLD_MS` (3 minutes) reste en place pour l’UI hint/auto-expansion.
- Conservé l’utilisation unique de `tone.color` pour le texte compact du temps et de `tone.bg` pour la barre afin de garantir un seul mapping de couleurs.
- Fichier modifié : `frontend/src/components/Common/Menu.js`.

### Testing
- Lint ciblé exécuté : `cd frontend && npm run lint -- src/components/Common/Menu.js src/muiThemeBuilder.js`; résultat : échec à cause d’erreurs ESLint préexistantes dans d’autres parties du repo qui ne sont pas liées à ce changement.
- Build exécuté : `cd frontend && npm run build`; résultat : succès (webpack a compilé, avec warnings de taille de bundle existants).
- Aucun test automatisé supplémentaire modifié ou exécuté par ce PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee6fc157d483328153a3aa2ca5cbfe)