### PR TITLE
Flowbox onboarding: split outside-range and permission-help dialogs

### DIFF
--- a/frontend/src/components/Flowbox/EnableLocation.js
+++ b/frontend/src/components/Flowbox/EnableLocation.js
@@ -13,7 +13,6 @@ export default function EnableLocation({
   open,
   boxTitle = "Boîte",
   loading = false,
-  error = "",
   onAuthorize,
   onClose,
 }) {
@@ -43,12 +42,6 @@ export default function EnableLocation({
           <Typography variant="body1">
             Pour éviter la triche, la boîte s’ouvre seulement si tu es sur place.
           </Typography>
-
-          {error ? (
-            <Typography variant="body1" color="error">
-              {error}
-            </Typography>
-          ) : null}
 
           <Button
             variant="contained"

--- a/frontend/src/components/Flowbox/Onboarding.js
+++ b/frontend/src/components/Flowbox/Onboarding.js
@@ -18,12 +18,47 @@ import EnableLocation from "./EnableLocation";
 import { FlowboxSessionContext } from "./runtime/FlowboxSessionContext";
 
 function getCookie(name) {
-  const match = document.cookie.match(new RegExp(`(^|;\s*)${name}=([^;]*)`));
+  const match = document.cookie.match(new RegExp(`(^|;\\s*)${name}=([^;]*)`));
   return match ? decodeURIComponent(match[2]) : "";
 }
 
 function isPermissionDeniedError(error) {
   return error?.code === 1 || /denied/i.test(String(error?.message || ""));
+}
+
+function getDeviceOs() {
+  const userAgent = navigator?.userAgent || "";
+  const platform = navigator?.platform || "";
+  const maxTouchPoints = navigator?.maxTouchPoints || 0;
+
+  const isIOS = /iPhone|iPad|iPod/i.test(userAgent)
+    || /iPhone|iPad|iPod/i.test(platform)
+    || (platform === "MacIntel" && maxTouchPoints > 1);
+  if (isIOS) {return "ios";}
+  if (/Android/i.test(userAgent)) {return "android";}
+  return "unknown";
+}
+
+function getPermissionDialogContent(os) {
+  const title = "Autorise la localisation pour continuer";
+  if (os === "ios") {
+    return {
+      title,
+      content: "Tu as refusé de partager ta localisation.\nOn ne peut pas vérifier que tu es près de la boîte tant que la localisation n’est pas activée.\nOuvre ton application Réglages, puis va dans Confidentialité et sécurité > Service de localisation et active-la.\nSi besoin, autorise aussi la localisation pour les sites dans Safari.\nEnsuite, reviens ici et recommence.",
+    };
+  }
+
+  if (os === "android") {
+    return {
+      title,
+      content: "Tu as refusé de partager ta localisation.\nOn ne peut pas vérifier que tu es près de la boîte tant que la localisation n’est pas activée.\nOuvre ton application Réglages, puis va dans Localisation et active-la.\nSi besoin, autorise aussi la localisation pour Chrome ou ton navigateur dans les autorisations des applications.\nEnsuite, reviens ici et recommence.",
+    };
+  }
+
+  return {
+    title,
+    content: "Tu as refusé de partager ta localisation.\nOn ne peut pas vérifier que tu es près de la boîte tant que la localisation n’est pas activée.\nOuvre ton application Réglages, active la localisation, puis autorise-la aussi pour ton navigateur si nécessaire.\nEnsuite, reviens ici et recommence.",
+  };
 }
 
 async function getLocationPermissionState() {
@@ -75,10 +110,12 @@ export default function Onboarding() {
   const [pageError, setPageError] = useState("");
   const [sheetOpen, setSheetOpen] = useState(false);
   const [geoLoading, setGeoLoading] = useState(false);
-  const [locationError, setLocationError] = useState("");
   const [settingsDialogOpen, setSettingsDialogOpen] = useState(false);
+  const [outsideRangeDialogOpen, setOutsideRangeDialogOpen] = useState(false);
 
   const boxName = runtime?.box?.name || "Boîte";
+  const deviceOs = getDeviceOs();
+  const permissionDialog = getPermissionDialogContent(deviceOs);
 
   useEffect(() => {
     const err = location.state?.error;
@@ -93,8 +130,9 @@ export default function Onboarding() {
 
   const verifyAndOpenBox = useCallback(async () => {
     setGeoLoading(true);
-    setLocationError("");
     setPageError("");
+    setSettingsDialogOpen(false);
+    setOutsideRangeDialogOpen(false);
 
     try {
       const position = await requestLocationOnce();
@@ -115,9 +153,13 @@ export default function Onboarding() {
 
       const data = await response.json().catch(() => ({}));
       if (!response.ok) {
-        if (response.status === 403) {
-          setLocationError(data?.detail || "Rapproche-toi de la boîte pour l’ouvrir.");
-          setSheetOpen(true);
+        const outsideRangeByCode = data?.code === "OUTSIDE_ALLOWED_BOX_RANGE";
+        const outsideRangeByMessage = /rapproche|près de la boîte|outside.*range/i.test(
+          String(data?.detail || "")
+        );
+        if (response.status === 403 && (outsideRangeByCode || outsideRangeByMessage)) {
+          setSheetOpen(false);
+          setOutsideRangeDialogOpen(true);
           return;
         }
         throw new Error(data?.detail || "Impossible d’ouvrir la boîte.");
@@ -144,7 +186,7 @@ export default function Onboarding() {
 
   const handleStart = useCallback(async () => {
     setPageError("");
-    setLocationError("");
+    setOutsideRangeDialogOpen(false);
     const permissionState = await getLocationPermissionState();
 
     if (permissionState === "granted") {
@@ -220,21 +262,39 @@ export default function Onboarding() {
         open={sheetOpen}
         boxTitle={boxName}
         loading={geoLoading}
-        error={locationError}
         onAuthorize={verifyAndOpenBox}
         onClose={() => setSheetOpen(false)}
       />
 
       <Dialog open={settingsDialogOpen} onClose={() => setSettingsDialogOpen(false)} fullWidth maxWidth="xs">
-        <DialogTitle>Active la localisation</DialogTitle>
+        <DialogTitle>{permissionDialog.title}</DialogTitle>
         <DialogContent>
-          <Typography variant="body1">
-            Pour ouvrir cette boîte, la localisation doit être autorisée pour ce site dans les réglages de ton téléphone ou de ton navigateur.
+          <Typography variant="body1" sx={{ whiteSpace: "pre-line" }}>
+            {permissionDialog.content}
           </Typography>
         </DialogContent>
         <DialogActions>
           <Button variant="light" onClick={() => setSettingsDialogOpen(false)}>
             Fermer
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog
+        open={outsideRangeDialogOpen}
+        onClose={() => setOutsideRangeDialogOpen(false)}
+        fullWidth
+        maxWidth="xs"
+      >
+        <DialogTitle>Tu es trop loin</DialogTitle>
+        <DialogContent>
+          <Typography variant="body1">
+            Rapproche-toi de la boîte pour l’ouvrir.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button variant="light" onClick={() => setOutsideRangeDialogOpen(false)}>
+            J’ai compris
           </Button>
         </DialogActions>
       </Dialog>


### PR DESCRIPTION
### Motivation
- Éviter l’affichage inline d’une erreur de distance dans le drawer de localisation pour que ce drawer soit uniquement un écran préparatoire à la demande de permission navigateur.
- Séparer clairement le cas métier « trop loin » (dialog dédié) du cas « permission refusée » (dialog d’aide), et garder le flow direct quand la permission est déjà accordée.
- Fournir un texte d’aide ciblé selon l’OS (iOS / Android / fallback) avec une détection légère et locale.

### Description
- Suppression de la prop/du rendu `error` dans `EnableLocation.js` pour enlever l’erreur inline rouge et faire du drawer un écran d’explication uniquement.
- Ajout d’une détection locale d’OS (`getDeviceOs`) et d’un helper `getPermissionDialogContent` dans `Onboarding.js` pour générer le contenu FR spécifique iOS/Android/fallback.
- Nouveau state `outsideRangeDialogOpen` et nouveau `Dialog` MUI dédié « Tu es trop loin » affichant `Rapproche-toi de la boîte pour l’ouvrir.`.
- `verifyAndOpenBox()` modifié pour : fermer le drawer et ouvrir le dialog distance quand le backend renvoie un 403 métier (priorise `data?.code === "OUTSIDE_ALLOWED_BOX_RANGE"` puis fallback sur message), et fermer le drawer + ouvrir le dialog d’aide OS-spécifique quand la permission est refusée.
- Conservation du comportement existant : si la permission est `granted`, `handleStart()` lance directement `verifyAndOpenBox()` sans ouvrir le drawer ; les autres erreurs techniques continuent de passer par `pageError`.
- Correction mineure de la regex de récupération du cookie (`\s` échappé) et retrait du state `locationError` devenu obsolète.

### Testing
- Lancé le lint ciblé : `cd frontend && npm run lint -- src/components/Flowbox/Onboarding.js src/components/Flowbox/EnableLocation.js` ; la commande a échoué à cause d’erreurs ESLint préexistantes dans le repo (le linter parcourt `src` globalement), et aucune nouvelle erreur introduite dans les fichiers modifiés n’a été détectée en local par l’édition.
- Build production : `cd frontend && npm run build` ; la compilation Webpack a réussi (build complété) avec des warnings de taille d’asset, pas d’erreurs critiques.
- Comportements manuels couverts par les changements : permission déjà accordée (direct verify → search), permission manquante (drawer → Autoriser → verify), 403 outside-range (drawer fermé → dialog « trop loin »), permission refusée (drawer fermé → dialog d’aide OS-spécifique).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4e0c16ec8332845cb37e628fa938)