### PR TITLE
Fix blank screen on /profile caused by conditional hook order

### DIFF
--- a/frontend/src/components/UserProfilePage.js
+++ b/frontend/src/components/UserProfilePage.js
@@ -237,43 +237,6 @@ export default function UserProfilePage() {
     });
   };
 
-  if (shouldCanonicalRedirect) {
-    return (
-      <Navigate
-        to={`/profile${location.search || ""}${location.hash || ""}`}
-        replace
-      />
-    );
-  }
-
-  if (header.status === "loading") {
-    return (
-      <Box sx={{ pb: 8 }}>
-        <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
-          <CircularProgress />
-        </Box>
-      </Box>
-    );
-  }
-
-  if (header.status === "not_found") {
-    return (
-      <Box sx={{ pb: 8, p: 2 }}>
-        <Typography>Ce profil est introuvable</Typography>
-      </Box>
-    );
-  }
-
-  if (header.status === "error") {
-    return (
-      <Box sx={{ pb: 8, p: 2 }}>
-        <Typography>
-          Une erreur s&apos;est produite, veuillez réessayer ulterieurement
-        </Typography>
-      </Box>
-    );
-  }
-
   const openFollowDrawer = (mode) => {
     openDrawerWithHistory({ navigate, location, param: "profileDrawer", value: mode });
   };
@@ -281,6 +244,8 @@ export default function UserProfilePage() {
   const closeFollowDrawer = () => {
     closeDrawerWithHistory({ navigate, location, param: "profileDrawer", value: followDrawerMode });
   };
+
+  const headerUser = header.user || {};
 
   const handleToggleFollow = async (target, forceMode = null) => {
     if (!user?.id || user?.is_guest) {
@@ -322,7 +287,42 @@ export default function UserProfilePage() {
       .finally(()=>setFollowDrawerLoading(false));
   }, [location.search, header.user?.username, routeUsername, user?.username]);
 
-  const headerUser = header.user || {};
+  if (shouldCanonicalRedirect) {
+    return (
+      <Navigate
+        to={`/profile${location.search || ""}${location.hash || ""}`}
+        replace
+      />
+    );
+  }
+
+  if (header.status === "loading") {
+    return (
+      <Box sx={{ pb: 8 }}>
+        <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
+          <CircularProgress />
+        </Box>
+      </Box>
+    );
+  }
+
+  if (header.status === "not_found") {
+    return (
+      <Box sx={{ pb: 8, p: 2 }}>
+        <Typography>Ce profil est introuvable</Typography>
+      </Box>
+    );
+  }
+
+  if (header.status === "error") {
+    return (
+      <Box sx={{ pb: 8, p: 2 }}>
+        <Typography>
+          Une erreur s&apos;est produite, veuillez réessayer ulterieurement
+        </Typography>
+      </Box>
+    );
+  }
   const totalDeposits = headerUser?.total_deposits ?? 0;
   const depositsCount = `${totalDeposits} partage${
     totalDeposits > 1 ? "s" : ""


### PR DESCRIPTION
### Motivation
- The profile page could render a blank screen because some React hooks and follow-related state were declared after early `return` branches, creating a hook-order mismatch across renders after the follow feature was added.
- The change aims to ensure all hooks run unconditionally so React hook ordering remains stable across renders.
- This preserves existing loading/not-found/error/canonical-redirect behavior while preventing runtime crashes that produce a blank page.

### Description
- Reordered code in `UserProfilePage` so follow-related state, `headerUser`, and the follow drawer `useEffect` are declared before any conditional `return` branches.
- Moved `handleToggleFollow` to use the earlier `headerUser` definition so follow logic remains consistent with the new ordering.
- Kept all existing UI output (loading spinner, not-found/error messages, redirect) unchanged and only changed declaration order to avoid hook-order issues.

### Testing
- Ran the linter with `cd frontend && npx eslint src/components/UserProfilePage.js`, which reported 13 problems (5 errors) including `import/order` and `no-unused-vars` for `forceMode`, so ESLint did not pass on this file.
- No unit tests were added or executed for this change.
- No build was performed as part of this automated validation step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f220706aa88332a18a44d2a0e98c63)