### PR TITLE
Make username handling case-insensitive across user and messaging flows

### DIFF
--- a/private_messages/tests.py
+++ b/private_messages/tests.py
@@ -127,6 +127,13 @@ class MessagingFlowTests(APITestCase):
         sender_after_expired = self.client.get(reverse("messages-summary"))
         self.assertEqual(sender_after_expired.data["conversations"], [])
 
+
+    def test_status_lookup_by_username_is_case_insensitive(self):
+        self.client.force_authenticate(self.sender)
+        response = self.client.get(reverse("messages-status", kwargs={"username": "BOB"}))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["target_user"]["username"], "bob")
+
     def test_settings_toggle_updates_user(self):
         self.client.force_authenticate(self.receiver)
         response = self.client.post(

--- a/private_messages/views.py
+++ b/private_messages/views.py
@@ -330,7 +330,7 @@ class MessageThreadStatusView(APIView):
 
         from users.models import CustomUser
 
-        target = CustomUser.objects.filter(username=username, is_guest=False).first()
+        target = CustomUser.objects.filter(username__iexact=username, is_guest=False).first()
         if not target:
             return api_error(status.HTTP_404_NOT_FOUND, "TARGET_USER_NOT_FOUND", "Utilisateur introuvable.")
 

--- a/users/forms.py
+++ b/users/forms.py
@@ -21,3 +21,15 @@ class RegisterUserForm(UserCreationForm):
         self.fields["username"].widget.attrs["class"] = "form-control"
         self.fields["password1"].widget.attrs["class"] = "form-control"
         self.fields["password2"].widget.attrs["class"] = "form-control"
+
+    def clean_username(self):
+        username = (self.cleaned_data.get("username") or "").strip()
+        if not username:
+            return username
+
+        duplicate = CustomUser.objects.filter(username__iexact=username)
+        if self.instance and self.instance.pk:
+            duplicate = duplicate.exclude(pk=self.instance.pk)
+        if duplicate.exists():
+            raise forms.ValidationError("Ce nom d’utilisateur est déjà pris.")
+        return username

--- a/users/migrations/0010_customuser_username_ci_unique.py
+++ b/users/migrations/0010_customuser_username_ci_unique.py
@@ -1,0 +1,40 @@
+from django.db import migrations, models
+from django.db.models.functions import Lower
+
+
+def assert_no_casefold_duplicates(apps, schema_editor):
+    CustomUser = apps.get_model("users", "CustomUser")
+    duplicates = (
+        CustomUser.objects.annotate(username_lower=Lower("username"))
+        .values("username_lower")
+        .annotate(n=models.Count("id"))
+        .filter(n__gt=1)
+    )
+
+    seen = {}
+    for row in duplicates:
+        key = row["username_lower"]
+        seen.setdefault(key, []).append(key)
+
+    if seen:
+        examples = ", ".join(
+            f"{lower}: {sorted(set(usernames))}" for lower, usernames in sorted(seen.items())[:5]
+        )
+        raise RuntimeError(
+            "Impossible d’ajouter la contrainte d’unicité case-insensitive sur users_customuser.username: "
+            f"doublons existants détectés ({examples})."
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0009_userfollow"),
+    ]
+
+    operations = [
+        migrations.RunPython(assert_no_casefold_duplicates, migrations.RunPython.noop),
+        migrations.AddConstraint(
+            model_name="customuser",
+            constraint=models.UniqueConstraint(Lower("username"), name="users_customuser_username_ci_unique"),
+        ),
+    ]

--- a/users/tests/test_user_follow.py
+++ b/users/tests/test_user_follow.py
@@ -13,6 +13,14 @@ class UserFollowTests(FlowboxAPITestCase):
         self.assertEqual(response.status_code, 201)
         self.assertTrue(response.data["followed"])
 
+    def test_follow_lookup_is_case_insensitive(self):
+        viewer = self.make_user(username="aliceci")
+        target = self.make_user(username="TargetCi")
+        self.auth(viewer)
+        response = self.client.post(reverse("user-follow", kwargs={"username": "targetci"}), {}, format="json")
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(response.data["followed"])
+
     def test_follow_idempotent(self):
         viewer = self.make_user(username="alice2")
         target = self.make_user(username="bob2")

--- a/users/tests/test_username_case_insensitive.py
+++ b/users/tests/test_username_case_insensitive.py
@@ -1,0 +1,38 @@
+from django.urls import reverse
+
+from box_management.tests.base import FlowboxAPITestCase
+
+
+class UsernameCaseInsensitiveTests(FlowboxAPITestCase):
+    def test_register_rejects_case_insensitive_duplicate_username(self):
+        self.make_user(username="Sio")
+
+        response = self.client.post(
+            reverse("register"),
+            {
+                "username": "sio",
+                "email": "sio2@example.com",
+                "password1": "StrongPass123!",
+                "password2": "StrongPass123!",
+            },
+            format="multipart",
+        )
+
+        self.assert_api_error(response, 400, "VALIDATION_ERROR")
+        self.assertIn("username", response.data.get("field_errors", {}))
+
+    def test_public_profile_lookup_is_case_insensitive_and_preserves_casing(self):
+        self.make_user(username="Sio")
+
+        for variant in ["sio", "SIO", "SiO"]:
+            response = self.client.get(reverse("get-user-info"), {"username": variant})
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.data["username"], "Sio")
+
+    def test_change_username_rejects_case_insensitive_duplicate(self):
+        self.make_user(username="Sio")
+        editor = self.make_user(username="OtherUser")
+        self.auth(editor)
+
+        response = self.client.post(reverse("change-username"), {"username": "sio"}, format="json")
+        self.assert_api_error(response, 409, "USERNAME_ALREADY_TAKEN")

--- a/users/views.py
+++ b/users/views.py
@@ -473,7 +473,7 @@ class ChangeUsername(APIView):
         if getattr(request.user, "is_guest", False):
             return api_error(status.HTTP_403_FORBIDDEN, "ACCOUNT_COMPLETION_REQUIRED", "Finalise d’abord ton compte.")
 
-        new_username = request.data.get("username") or request.data.get("new_username")
+        new_username = (request.data.get("username") or request.data.get("new_username") or "").strip()
         if not new_username:
             return api_error(
                 status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
### Motivation
- Ensure usernames are treated identically regardless of letter case across user registration, profile lookups, follow/unfollow and private-messaging flows. 
- Prevent accidental duplicates that differ only by case and make business comparisons robust without changing displayed casing.

### Description
- Add `clean_username` to `RegisterUserForm` to enforce case-insensitive uniqueness on registration by checking `CustomUser.objects.filter(username__iexact=...)` and excluding the instance when editing. 
- Normalize username input on rename by trimming the incoming value and keep the existing `username__iexact` conflict check in `ChangeUsername`. 
- Make private message status lookup case-insensitive by changing the lookup to `CustomUser.objects.filter(username__iexact=...)` in `MessageThreadStatusView`. 
- Add a DB migration that attempts to add a PostgreSQL-friendly functional unique constraint `UniqueConstraint(Lower('username'))` and includes a pre-check that aborts the migration with an explicit error if case-insensitive duplicates already exist. 
- Add and adapt tests: new `users/tests/test_username_case_insensitive.py`, a follow lookup test in `users/tests/test_user_follow.py`, and a messaging status test in `private_messages/tests.py` to assert case-insensitive behavior and that stored casing is preserved in responses. 

### Testing
- Ran `python manage.py check` which returned no system check issues. 
- Ran targeted tests `python manage.py test users.tests.test_username_case_insensitive users.tests.test_user_follow private_messages.tests --keepdb` which passed (OK). 
- Ran the broader suite `python manage.py test users.tests private_messages.tests box_management.tests` where test failures occurred in existing `box_management` seed activity tests unrelated to username changes (4 failing tests). 
- Built frontend with `npm --prefix frontend run build` which completed successfully (webpack compiled, warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f88a21dc8332ae9d5dd68c52354d)