### PR TITLE
Simplify private message payloads, add thread-by-username endpoint, and update frontend consumers

### DIFF
--- a/frontend/src/components/Messages/Conversation.js
+++ b/frontend/src/components/Messages/Conversation.js
@@ -286,7 +286,7 @@ export default function Conversation({
 
           <Stack spacing={4} ref={messagesContainerRef} sx={{ overflowY: "auto", flex: 1, minHeight: 120}}>
             {(thread?.messages || []).map((message) => {
-              const isOwnMessage = message?.sender?.id === currentViewer.id;
+              const isOwnMessage = message?.sender_id === currentViewer.id;
               return (
                 <Box
                   key={message.id}

--- a/frontend/src/components/Messages/MessagesPage.js
+++ b/frontend/src/components/Messages/MessagesPage.js
@@ -44,13 +44,12 @@ function getItemsForTab(summary, tab) {
 }
 
 function MessageRow({ item, active, onClick }) {
-  let preview = item?.last_message?.text || "";
+  let preview = item?.last_message?.text_preview || "";
   if (!preview && item?.last_message?.message_type === "song") {
-    preview = "A partagé une chanson";
+    const songTitle = item?.last_message?.song?.title;
+    preview = songTitle ? `A partagé : ${songTitle}` : "A partagé une chanson";
   }
-  if (!preview && item?.is_pending_sent) {
-    preview = "En attente de réponse";
-  }
+  if (!preview && item?.status === "pending") { preview = "En attente de réponse"; }
 
   return (
     <ListItemButton
@@ -96,7 +95,7 @@ function MessageRow({ item, active, onClick }) {
         }}
       >
         <Typography variant="caption" sx={{ flex: "0 0 auto", pt: 0.5, whiteSpace: "nowrap" }}>
-          {formatRelativeTime(item?.updated_at)}
+          {formatRelativeTime(item?.last_message?.created_at || item?.updated_at)}
         </Typography>
 
         {item?.has_unread ? (

--- a/private_messages/services/payloads.py
+++ b/private_messages/services/payloads.py
@@ -27,18 +27,28 @@ def _build_song_payload(song):
         "public_key": song.public_key,
         "title": song.title,
         "artist": song.artist,
-        "image_url": song.image_url,
         "image_url_small": song.image_url_small,
     }
 
 
-def _build_message_payload(message):
+def _build_thread_message_payload(message):
     return {
         "id": message.id,
         "message_type": message.message_type,
         "text": message.text,
         "song": _build_song_payload(message.song),
-        "sender": _build_user_payload(message.sender),
+        "sender_id": message.sender_id,
+        "created_at": message.created_at.isoformat() if message.created_at else None,
+    }
+
+
+def _build_last_message_payload(message):
+    return {
+        "id": message.id,
+        "message_type": message.message_type,
+        "text_preview": message.text if message.message_type == "text" else None,
+        "song": _build_song_payload(message.song),
+        "sender_id": message.sender_id,
         "created_at": message.created_at.isoformat() if message.created_at else None,
     }
 
@@ -52,17 +62,28 @@ def build_thread_payload(thread, current_user):
     return {
         "id": thread.id,
         "status": thread.status,
-        "initiator_id": thread.initiator_id,
         "other_user": _build_user_payload(other),
-        "accepted_at": thread.accepted_at.isoformat() if thread.accepted_at else None,
-        "refused_at": thread.refused_at.isoformat() if thread.refused_at else None,
-        "expired_at": thread.expired_at.isoformat() if thread.expired_at else None,
-        "expires_at": thread.expires_at.isoformat() if thread.expires_at else None,
         "updated_at": thread.updated_at.isoformat() if thread.updated_at else None,
-        "is_pending_sent": thread.status == ChatThread.STATUS_PENDING and thread.initiator_id == current_user.id,
-        "is_pending_received": thread.status == ChatThread.STATUS_PENDING and thread.initiator_id != current_user.id,
         "has_unread": thread_has_unread_for_user(thread, current_user),
-        "messages": [_build_message_payload(message) for message in messages],
-        "last_message": _build_message_payload(last_message) if last_message else None,
+        "unread_count": 1 if thread_has_unread_for_user(thread, current_user) else 0,
+        "messages": [_build_thread_message_payload(message) for message in messages],
+        "last_message": _build_last_message_payload(last_message) if last_message else None,
         "server_time": timezone.now().isoformat(),
+    }
+
+
+def build_summary_thread_payload(thread, current_user):
+    thread.ensure_not_expired()
+    other = thread.other_user(current_user)
+    last_message = thread.messages.select_related("song").order_by("-created_at", "-id").first()
+    has_unread = thread_has_unread_for_user(thread, current_user)
+
+    return {
+        "id": thread.id,
+        "status": thread.status,
+        "other_user": _build_user_payload(other),
+        "last_message": _build_last_message_payload(last_message) if last_message else None,
+        "has_unread": has_unread,
+        "unread_count": 1 if has_unread else 0,
+        "updated_at": thread.updated_at.isoformat() if thread.updated_at else None,
     }

--- a/private_messages/tests.py
+++ b/private_messages/tests.py
@@ -76,6 +76,9 @@ class MessagingFlowTests(APITestCase):
         self.assertEqual(sender_summary.status_code, status.HTTP_200_OK)
         self.assertEqual(sender_summary.data["unread_conversations_count"], 1)
         self.assertTrue(sender_summary.data["conversations"][0]["has_unread"])
+        self.assertNotIn("messages", sender_summary.data["conversations"][0])
+        self.assertIn("text_preview", sender_summary.data["conversations"][0]["last_message"])
+        self.assertIn("sender_id", sender_summary.data["conversations"][0]["last_message"])
 
     def test_pending_then_reply_accepts(self):
         thread_id = self.start_thread()
@@ -101,13 +104,13 @@ class MessagingFlowTests(APITestCase):
         )
         self.assertEqual(blocked.status_code, status.HTTP_409_CONFLICT)
 
-    def test_summary_filters_pending_sent_pending_received_refused_expired(self):
+    def test_summary_filters_pending_received_and_accepted_only(self):
         thread_id = self.start_thread()
         thread = ChatThread.objects.get(pk=thread_id)
 
         self.client.force_authenticate(self.sender)
         sender_summary = self.client.get(reverse("messages-summary"))
-        self.assertEqual(len(sender_summary.data["conversations"]), 1)
+        self.assertEqual(len(sender_summary.data["conversations"]), 0)
 
         self.client.force_authenticate(self.receiver)
         receiver_summary = self.client.get(reverse("messages-summary"))
@@ -142,3 +145,44 @@ class MessagingFlowTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.receiver.refresh_from_db()
         self.assertFalse(self.receiver.allow_private_message_requests)
+
+    def test_thread_detail_payload_is_simplified(self):
+        thread_id = self.start_thread()
+        self.client.force_authenticate(self.receiver)
+        self.client.post(reverse("messages-thread-reply", kwargs={"thread_id": thread_id}), {"text": "ok"}, format="json")
+        self.client.force_authenticate(self.sender)
+        response = self.client.get(reverse("messages-thread-detail", kwargs={"thread_id": thread_id}))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        message = response.data["messages"][0]
+        self.assertIn("sender_id", message)
+        self.assertNotIn("sender", message)
+        self.assertIn("image_url_small", message["song"])
+        self.assertNotIn("image_url", message["song"])
+
+    def test_thread_by_username_returns_existing_thread_case_insensitive(self):
+        thread_id = self.start_thread()
+        self.client.force_authenticate(self.sender)
+        response = self.client.get(reverse("messages-thread-by-username", kwargs={"username": "BOB"}))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], thread_id)
+
+    def test_thread_by_username_returns_virtual_thread_when_missing(self):
+        self.client.force_authenticate(self.sender)
+        response = self.client.get(reverse("messages-thread-by-username", kwargs={"username": "bob"}))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.data["id"])
+        self.assertEqual(response.data["status"], "new")
+        self.assertEqual(response.data["messages"], [])
+        self.assertEqual(ChatThread.objects.count(), 0)
+
+    def test_thread_by_username_returns_user_not_found(self):
+        self.client.force_authenticate(self.sender)
+        response = self.client.get(reverse("messages-thread-by-username", kwargs={"username": "unknown_user"}))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["code"], "USER_NOT_FOUND")
+
+    def test_thread_by_username_self_is_forbidden(self):
+        self.client.force_authenticate(self.sender)
+        response = self.client.get(reverse("messages-thread-by-username", kwargs={"username": "alice"}))
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["code"], "SELF_CHAT_FORBIDDEN")

--- a/private_messages/urls.py
+++ b/private_messages/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from private_messages.views import (
     MessageSettingsView,
     MessageSummaryView,
+    MessageThreadByUsernameDetailView,
     MessageThreadDetailView,
     MessageThreadRefuseView,
     MessageThreadReplyView,
@@ -13,6 +14,7 @@ from private_messages.views import (
 urlpatterns = [
     path("summary", MessageSummaryView.as_view(), name="messages-summary"),
     path("thread/<int:thread_id>", MessageThreadDetailView.as_view(), name="messages-thread-detail"),
+    path("threads/by-username/<str:username>", MessageThreadByUsernameDetailView.as_view(), name="messages-thread-by-username"),
     path("thread/start", MessageThreadStartView.as_view(), name="messages-thread-start"),
     path("thread/<int:thread_id>/reply", MessageThreadReplyView.as_view(), name="messages-thread-reply"),
     path("thread/<int:thread_id>/refuse", MessageThreadRefuseView.as_view(), name="messages-thread-refuse"),

--- a/private_messages/views.py
+++ b/private_messages/views.py
@@ -17,7 +17,7 @@ from la_boite_a_son.api_errors import api_error
 from private_messages.models import ChatMessage, ChatThread
 from private_messages.selectors.threads import get_thread_for_users, list_threads_for_user, sorted_pair
 from private_messages.services.moderation import validate_message_text
-from private_messages.services.payloads import build_thread_payload
+from private_messages.services.payloads import build_summary_thread_payload, build_thread_payload
 from private_messages.services.read_state import set_last_read_at_for_user
 from users.utils import get_current_app_user, touch_last_seen
 
@@ -70,10 +70,11 @@ class MessageSummaryView(APIView):
         conversations = []
 
         for thread in list_threads_for_user(user.id):
-            payload = build_thread_payload(thread, user)
-            if payload["is_pending_received"]:
+            payload = build_summary_thread_payload(thread, user)
+            is_pending_received = thread.status == ChatThread.STATUS_PENDING and thread.initiator_id != user.id
+            if is_pending_received:
                 received_requests.append(payload)
-            if thread.status == ChatThread.STATUS_ACCEPTED or payload["is_pending_sent"]:
+            if thread.status == ChatThread.STATUS_ACCEPTED:
                 conversations.append(payload)
 
         unread_conversations_count = sum(1 for item in conversations if item.get("has_unread"))
@@ -102,6 +103,47 @@ class MessageThreadDetailView(APIView):
 
         set_last_read_at_for_user(thread, user, timezone.now())
         return Response(build_thread_payload(thread, user), status=status.HTTP_200_OK)
+
+
+class MessageThreadByUsernameDetailView(APIView):
+    def get(self, request, username, format=None):
+        user, error = _get_authenticated_non_guest_user(request)
+        if error:
+            return error
+
+        from users.models import CustomUser
+
+        target = CustomUser.objects.filter(username__iexact=username, is_guest=False).first()
+        if not target:
+            return api_error(status.HTTP_404_NOT_FOUND, "USER_NOT_FOUND", "Utilisateur introuvable.")
+
+        if target.id == user.id:
+            return api_error(status.HTTP_400_BAD_REQUEST, "SELF_CHAT_FORBIDDEN", "Tu ne peux pas t’écrire à toi-même.")
+
+        thread = get_thread_for_users(user.id, target.id)
+        if thread:
+            thread.ensure_not_expired()
+            set_last_read_at_for_user(thread, user, timezone.now())
+            return Response(build_thread_payload(thread, user), status=status.HTTP_200_OK)
+
+        return Response(
+            {
+                "id": None,
+                "status": "new",
+                "other_user": {
+                    "id": target.id,
+                    "username": target.username,
+                    "display_name": target.display_name,
+                    "profile_picture_url": target.profile_picture.url if getattr(target, "profile_picture", None) else None,
+                },
+                "has_unread": False,
+                "unread_count": 0,
+                "updated_at": None,
+                "server_time": timezone.now().isoformat(),
+                "messages": [],
+            },
+            status=status.HTTP_200_OK,
+        )
 
 
 class MessageThreadStartView(APIView):


### PR DESCRIPTION
### Motivation
- Reduce payload size and complexity for message threads by returning only the fields the client needs (e.g. `sender_id` and a text preview) to improve efficiency and decouple frontend shape from ORM objects.
- Provide a convenient endpoint to fetch a thread by username (case-insensitive) that returns an existing thread or a virtual "new" thread when none exists.
- Update frontend components to consume the new payload shape and show improved previews and timestamps consistently.

### Description
- Refactored `private_messages.services.payloads` to split message payloads into `_build_thread_message_payload` and `_build_last_message_payload`, removed nested `sender` objects in favor of `sender_id`, and returned `text_preview` and `image_url_small` instead of full-sized `image_url` in songs.
- Simplified `build_thread_payload` (removed many fields) and added `build_summary_thread_payload` to produce compact thread summaries for the messages list.
- Added `MessageThreadByUsernameDetailView` and a corresponding URL `threads/by-username/<str:username>` to return either an existing thread or a virtual thread payload when missing, with case-insensitive username lookup and proper error codes for not-found and self-chat.
- Updated `MessageSummaryView` to use the new summary payload and to only include pending-received and accepted conversations in the appropriate lists.
- Adjusted frontend: `Conversation.js` now compares `message.sender_id` against `currentViewer.id`, and `MessagesPage.js` uses `last_message.text_preview` and `last_message.created_at` for previews and timestamps and shows song title when available.
- Added and updated tests in `private_messages/tests.py` to assert the new payload shapes, summary filtering, thread-by-username behaviors, and message payload simplifications.

### Testing
- Ran the Django `private_messages` test suite via `python manage.py test private_messages`, and all tests passed after the changes.
- Executed the frontend test/verification steps via `yarn test` / component checks to ensure updated components render with the new payload shape, and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f315fe6250833286f561e7206ef1d7)