### PR TITLE
Add Django Admin coverage for follows, chat threads and messages

### DIFF
--- a/private_messages/admin.py
+++ b/private_messages/admin.py
@@ -1,0 +1,140 @@
+from django.contrib import admin
+from django.db.models import Count, Max
+
+from private_messages.models import ChatMessage, ChatThread
+
+
+class ChatMessageInline(admin.TabularInline):
+    model = ChatMessage
+    extra = 0
+    can_delete = False
+    fields = (
+        "id",
+        "sender",
+        "message_type",
+        "text",
+        "song",
+        "created_at",
+    )
+    readonly_fields = (
+        "id",
+        "sender",
+        "message_type",
+        "text",
+        "song",
+        "created_at",
+    )
+    autocomplete_fields = (
+        "sender",
+        "song",
+    )
+    ordering = (
+        "created_at",
+        "id",
+    )
+
+
+@admin.register(ChatThread)
+class ChatThreadAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "user_a",
+        "user_b",
+        "initiator",
+        "status",
+        "messages_count",
+        "last_message_at",
+        "created_at",
+        "updated_at",
+        "accepted_at",
+        "refused_at",
+        "expired_at",
+    )
+    list_filter = (
+        "status",
+        "created_at",
+        "updated_at",
+        "accepted_at",
+        "refused_at",
+        "expired_at",
+    )
+    search_fields = (
+        "user_a__username",
+        "user_b__username",
+        "initiator__username",
+        "user_a__email",
+        "user_b__email",
+        "initiator__email",
+        "messages__text",
+    )
+    autocomplete_fields = (
+        "user_a",
+        "user_b",
+        "initiator",
+    )
+    readonly_fields = (
+        "created_at",
+        "updated_at",
+        "accepted_at",
+        "refused_at",
+        "expired_at",
+        "expires_at",
+        "user_a_last_read_at",
+        "user_b_last_read_at",
+    )
+    inlines = (ChatMessageInline,)
+    ordering = ("-updated_at",)
+
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        return queryset.annotate(
+            _messages_count=Count("messages", distinct=True),
+            _last_message_at=Max("messages__created_at"),
+        )
+
+    @admin.display(description="Messages")
+    def messages_count(self, obj):
+        return getattr(obj, "_messages_count", obj.messages.count())
+
+    @admin.display(description="Last message")
+    def last_message_at(self, obj):
+        return getattr(obj, "_last_message_at", None)
+
+
+@admin.register(ChatMessage)
+class ChatMessageAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "thread",
+        "sender",
+        "message_type",
+        "short_text",
+        "song",
+        "created_at",
+    )
+    list_filter = (
+        "message_type",
+        "created_at",
+    )
+    search_fields = (
+        "text",
+        "sender__username",
+        "sender__email",
+        "thread__user_a__username",
+        "thread__user_b__username",
+        "song__title",
+        "song__artist",
+    )
+    autocomplete_fields = (
+        "thread",
+        "sender",
+        "song",
+    )
+    readonly_fields = ("created_at",)
+    ordering = ("-created_at",)
+
+    @admin.display(description="Text")
+    def short_text(self, obj):
+        if not obj.text:
+            return ""
+        return obj.text[:80] + ("…" if len(obj.text) > 80 else "")

--- a/users/admin.py
+++ b/users/admin.py
@@ -1,7 +1,8 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
+from django.db.models import Count
 
-from users.models import CustomUser, UserProviderConnection
+from users.models import CustomUser, UserFollow, UserProviderConnection
 
 
 @admin.register(CustomUser)
@@ -77,6 +78,8 @@ class CustomUserAdmin(UserAdmin):
         "converted_at",
         "is_staff",
         "is_active",
+        "followers_count",
+        "following_count",
     )
     list_filter = (
         "is_guest",
@@ -98,6 +101,44 @@ class CustomUserAdmin(UserAdmin):
     autocomplete_fields = ("client",)
     readonly_fields = ("guest_device_token", "last_seen_at", "converted_at")
     ordering = ("username",)
+
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        return queryset.annotate(
+            _followers_count=Count("follower_relations", distinct=True),
+            _following_count=Count("following_relations", distinct=True),
+        )
+
+    @admin.display(description="Followers")
+    def followers_count(self, obj):
+        return getattr(obj, "_followers_count", obj.follower_relations.count())
+
+    @admin.display(description="Following")
+    def following_count(self, obj):
+        return getattr(obj, "_following_count", obj.following_relations.count())
+
+
+@admin.register(UserFollow)
+class UserFollowAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "follower",
+        "following",
+        "created_at",
+    )
+    list_filter = ("created_at",)
+    search_fields = (
+        "follower__username",
+        "following__username",
+        "follower__email",
+        "following__email",
+    )
+    autocomplete_fields = (
+        "follower",
+        "following",
+    )
+    readonly_fields = ("created_at",)
+    ordering = ("-created_at",)
 
 
 @admin.register(UserProviderConnection)


### PR DESCRIPTION
### Motivation
- Expose existing `UserFollow` relationships in Django Admin to inspect who follows whom and when.
- Provide quick follower/following counters on `CustomUser` to aid administration without modifying models.
- Add an admin interface for private chats so staff can inspect chat threads and their messages safely.

### Description
- Updated `users/admin.py` to import and register `UserFollow` and to add `followers_count` and `following_count` to `CustomUserAdmin` with an annotated `get_queryset` using `Count` to avoid N+1 queries. 
- Created `private_messages/admin.py` with `ChatThreadAdmin` and `ChatMessageAdmin`, including a readonly `ChatMessageInline` on threads, `autocomplete_fields`, `search_fields`, `list_display`/`list_filter`, and readonly timestamp fields. 
- Optimized `ChatThreadAdmin` with `get_queryset` annotations (`Count("messages")` and `Max("messages__created_at")`) to provide `messages_count` and `last_message_at` without per-row queries and to correctly show `None` for threads without messages. 
- Kept timestamps readonly, avoided model changes or migrations, and enabled `song` autocomplete because `SongAdmin` already defines `search_fields`.

### Testing
- Ran `python manage.py check` which reported no issues. 
- Ran `python manage.py test users.tests private_messages.tests` which executed 31 tests and completed successfully (`OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5b0a050308332af48afca3df2dfe3)