### PR TITLE
Update Deposit action icons

### DIFF
--- a/frontend/src/components/Common/Deposit/Deposit.js
+++ b/frontend/src/components/Common/Deposit/Deposit.js
@@ -1,5 +1,5 @@
 
-import AddReactionOutlinedIcon from "@mui/icons-material/AddReactionRounded";
+import ThumbUpRoundedIcon from "@mui/icons-material/ThumbUpRounded";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDownRounded";
 import LibraryMusicIcon from "@mui/icons-material/LibraryMusicRounded";
 import ModeCommentOutlinedIcon from "@mui/icons-material/ModeCommentRounded";
@@ -689,7 +689,7 @@ export default function Deposit({
                 {myReactionEmoji}
               </Typography>
             ) : (
-              <AddReactionOutlinedIcon />
+              <ThumbUpRoundedIcon />
             )}
           </Button>
   

--- a/frontend/src/components/Common/Deposit/parts/DepositLink.js
+++ b/frontend/src/components/Common/Deposit/parts/DepositLink.js
@@ -1,9 +1,17 @@
-import SendIcon from "@mui/icons-material/SendRounded";
+import IosShareRoundedIcon from "@mui/icons-material/IosShareRounded";
+import ShareRoundedIcon from "@mui/icons-material/ShareRounded";
 import Button from "@mui/material/Button";
 import React from "react";
 
 export default function DepositLink({ canShare, isSharing, onShare }) {
   if (!canShare) {return null;}
+
+  const isApplePlatform =
+    typeof navigator !== "undefined" &&
+    /iPad|iPhone|iPod|Macintosh|MacIntel|MacPPC|Mac68K/.test(
+      navigator.platform || navigator.userAgent || ""
+    );
+  const ShareIcon = isApplePlatform ? IosShareRoundedIcon : ShareRoundedIcon;
 
   return (
     <Button
@@ -14,7 +22,7 @@ export default function DepositLink({ canShare, isSharing, onShare }) {
       title="Partager"
       disabled={isSharing}
     >
-      <SendIcon />
+      <ShareIcon />
     </Button>
   );
 }


### PR DESCRIPTION
### Motivation
- Use rounded MUI icons and a more coherent platform-specific share icon for the Deposit UI by replacing the current send/reaction icons with the appropriate rounded variants.

### Description
- Replaced `SendRounded` with `ShareRounded` (default) and `IosShareRounded` (for iOS/macOS) and added a small `navigator`-based Apple platform detection in `frontend/src/components/Common/Deposit/parts/DepositLink.js`, and replaced `AddReactionRounded` with `ThumbUpRounded` in `frontend/src/components/Common/Deposit/Deposit.js` without changing handlers, texts, routes or styling.

### Testing
- Ran `npm test -- --runInBand Deposit` which passed, ran `npm run build` which completed successfully (webpack compiled with size warnings), and verified icon occurrences with `rg` to confirm old icons removed and new rounded icons in place.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6d2157108332b708914a522563e7)