### PR TITLE
Make LiveSearchSection stick on scroll before deposit and smooth-scroll to anchor after deposit

### DIFF
--- a/frontend/assets/scss/3-component/_box.scss
+++ b/frontend/assets/scss/3-component/_box.scss
@@ -29,6 +29,14 @@
   padding: 16px;
 }
 
+.liveSearch_section_anchor {
+  scroll-margin-top: var(--mm-app-header-height, 72px);
+}
+
+.liveSearch_slot {
+  position: relative;
+}
+
 .liveSearch {
   box-shadow: 0 4px 8px -4px rgba(0,0,0,.2);
   display: flex;
@@ -38,4 +46,8 @@
   border: var(--mm-border-default);
   border-radius: var(--mm-radius-xl);
   gap: 12px;
+}
+
+.liveSearch.fixed {
+  position: fixed;
 }

--- a/frontend/assets/scss/3-component/_box.scss
+++ b/frontend/assets/scss/3-component/_box.scss
@@ -29,14 +29,6 @@
   padding: 16px;
 }
 
-.liveSearch_section_anchor {
-  scroll-margin-top: var(--mm-app-header-height, 72px);
-}
-
-.liveSearch_slot {
-  position: relative;
-}
-
 .liveSearch {
   box-shadow: 0 4px 8px -4px rgba(0,0,0,.2);
   display: flex;
@@ -46,8 +38,24 @@
   border: var(--mm-border-default);
   border-radius: var(--mm-radius-xl);
   gap: 12px;
+  background: var(--mm-color-surface);
+  gap: 12px;
+  transition: all 0.3s;
+}
+
+.liveSearch_slot {
+    position: relative;
+    min-height: 184px;
+    height: auto;
+    transition: all 0.3s;
 }
 
 .liveSearch.fixed {
-  position: fixed;
+    position: fixed;
+    top: 64px;
+    left: 0px;
+    right: 0;
+    z-index: 200;
+    margin: 0;
+    border-radius: 0;
 }

--- a/frontend/assets/scss/3-component/_box.scss
+++ b/frontend/assets/scss/3-component/_box.scss
@@ -44,10 +44,9 @@
 }
 
 .liveSearch_slot {
-    position: relative;
-    min-height: 184px;
-    height: auto;
-    transition: all 0.3s;
+  position: relative;
+  height: auto;
+  transition: all 0.3s;
 }
 
 .liveSearch.fixed {

--- a/frontend/src/components/Flowbox/Discover.test.js
+++ b/frontend/src/components/Flowbox/Discover.test.js
@@ -18,10 +18,13 @@ jest.mock('../Common/Deposit', () => ({
 
 jest.mock('../Common/Search/SearchPanel', () => ({
   __esModule: true,
-  default: ({ onSelectSong }) => (
+  default: ({ onDepositVisualComplete, onSelectSong }) => (
     <button
       type="button"
-      onClick={() => onSelectSong({ id: 'track-1', name: 'Posted song', artist: 'Artist', image_url: 'cover.jpg' }, 'request-1')}
+      onClick={async () => {
+        await onSelectSong({ id: 'track-1', name: 'Posted song', artist: 'Artist', image_url: 'cover.jpg' }, 'request-1');
+        onDepositVisualComplete?.('request-1');
+      }}
     >
       Choisir Posted song
     </button>
@@ -151,6 +154,7 @@ describe('Discover', () => {
     jest.clearAllMocks();
     intersectionObservers = [];
     delete window.IntersectionObserver;
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
   });
 
   function mockIntersectionObserver() {
@@ -244,7 +248,7 @@ describe('Discover', () => {
 
     const mainDeposit = await screen.findByTestId('deposit-main');
     const liveSearchHeading = screen.getByRole('heading', {
-      name: /Partage une chanson pour gagner des points/i,
+      name: /Ajoute une chanson/i,
       level: 3,
     });
     const article = await screen.findByTestId('article-card');
@@ -269,7 +273,7 @@ describe('Discover', () => {
 
     const emptyState = await screen.findByText(/Aucune chanson à découvrir/i);
     const liveSearchHeading = screen.getByRole('heading', {
-      name: /Partage une chanson pour gagner des points/i,
+      name: /Ajoute une chanson/i,
       level: 3,
     });
     const article = await screen.findByTestId('article-card');

--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.js
@@ -277,7 +277,7 @@ export default function LiveSearchSection({
             ref={liveSearchCardRef}
             className={`liveSearch${isLiveSearchFixed ? " fixed" : ""}`}
           >
-            <Typography component="h3" variant="h4">
+            <Typography component="h3" variant="h5">
               Ajoute une chanson à la boîte et gagne pleins de points
             </Typography>
 

--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.js
@@ -271,7 +271,7 @@ export default function LiveSearchSection({
         <Box
           ref={liveSearchSlotRef}
           className="liveSearch_slot"
-        /*  style={isLiveSearchFixed && liveSearchHeight > 0 ? { minHeight: liveSearchHeight } : undefined}*/
+          style={isLiveSearchFixed && liveSearchHeight > 0 ? { minHeight: liveSearchHeight } : undefined}
         >
           <Box
             ref={liveSearchCardRef}

--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.js
@@ -271,7 +271,7 @@ export default function LiveSearchSection({
         <Box
           ref={liveSearchSlotRef}
           className="liveSearch_slot"
-          style={isLiveSearchFixed && liveSearchHeight > 0 ? { minHeight: liveSearchHeight } : undefined}
+        /*  style={isLiveSearchFixed && liveSearchHeight > 0 ? { minHeight: liveSearchHeight } : undefined}*/
         >
           <Box
             ref={liveSearchCardRef}

--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.js
@@ -23,6 +23,19 @@ const LIVE_SEARCH_DRAWER_VALUE = "live-search";
 const DEFAULT_ERROR_MESSAGE = "Impossible de partager cette chanson pour le moment.";
 const ALREADY_EXISTS_MESSAGE = "Tu as déjà partagé une chanson dans cette session.";
 
+function getHeaderBottomOffset() {
+  const header = document.querySelector(".MuiAppBar-root, header");
+  if (header) {
+    const headerRect = header.getBoundingClientRect();
+    if (Number.isFinite(headerRect.bottom)) {return Math.max(0, headerRect.bottom);}
+  }
+
+  const cssHeaderHeight = getComputedStyle(document.documentElement)
+    .getPropertyValue("--mm-app-header-height");
+  const parsedHeaderHeight = Number.parseFloat(cssHeaderHeight);
+  return Number.isFinite(parsedHeaderHeight) ? parsedHeaderHeight : 0;
+}
+
 function normalizeDepositResponse(data) {
   return {
     myDeposit: data?.my_deposit || null,
@@ -63,10 +76,52 @@ export default function LiveSearchSection({
     errorMessage: null,
   });
   const searchInputRef = useRef(null);
+  const sectionAnchorRef = useRef(null);
+  const liveSearchSlotRef = useRef(null);
+  const liveSearchCardRef = useRef(null);
   const isPostingRef = useRef(false);
   const pendingDepositResultRef = useRef(null);
+  const pendingScrollToSectionRef = useRef(false);
+  const [isLiveSearchFixed, setIsLiveSearchFixed] = useState(false);
+  const [liveSearchHeight, setLiveSearchHeight] = useState(0);
 
   const hasDeposit = Boolean(myDeposit);
+
+  const updateLiveSearchFixedState = useCallback(() => {
+    if (hasDeposit || !liveSearchSlotRef.current || !liveSearchCardRef.current) {
+      setIsLiveSearchFixed(false);
+      setLiveSearchHeight(0);
+      return;
+    }
+
+    const slotRect = liveSearchSlotRef.current.getBoundingClientRect();
+    const cardRect = liveSearchCardRef.current.getBoundingClientRect();
+    const headerBottom = getHeaderBottomOffset();
+
+    setLiveSearchHeight((currentHeight) => {
+      const nextHeight = Math.ceil(cardRect.height || liveSearchCardRef.current?.offsetHeight || 0);
+      return currentHeight === nextHeight ? currentHeight : nextHeight;
+    });
+    const nextFixed = slotRect.top <= headerBottom;
+    setIsLiveSearchFixed((currentFixed) => currentFixed === nextFixed ? currentFixed : nextFixed);
+  }, [hasDeposit]);
+
+  useEffect(() => {
+    if (hasDeposit) {
+      setIsLiveSearchFixed(false);
+      setLiveSearchHeight(0);
+      return undefined;
+    }
+
+    updateLiveSearchFixedState();
+    window.addEventListener("scroll", updateLiveSearchFixedState, { passive: true });
+    window.addEventListener("resize", updateLiveSearchFixedState);
+
+    return () => {
+      window.removeEventListener("scroll", updateLiveSearchFixedState);
+      window.removeEventListener("resize", updateLiveSearchFixedState);
+    };
+  }, [hasDeposit, updateLiveSearchFixedState]);
 
   useEffect(() => {
     const shouldOpenDrawer = !hasDeposit && matchesDrawerSearch(
@@ -122,9 +177,17 @@ export default function LiveSearchSection({
     }
 
     pendingDepositResultRef.current = null;
+    pendingScrollToSectionRef.current = true;
     isPostingRef.current = false;
     closeDrawer();
   }, [closeDrawer, onDepositCreated, setUser]);
+
+  useEffect(() => {
+    if (drawerOpen || !pendingScrollToSectionRef.current) {return;}
+
+    pendingScrollToSectionRef.current = false;
+    sectionAnchorRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, [drawerOpen]);
 
   const handleDepositError = useCallback((data, response) => {
     if (response?.status === 403 && data?.code === "BOX_SESSION_REQUIRED") {
@@ -194,74 +257,83 @@ export default function LiveSearchSection({
     }
   }, [boxSlug, handleDepositError, hasDeposit]);
 
-  if (hasDeposit) {
-    return (
-      <MyDeposit
-        deposit={myDeposit}
-        successes={successes}
-        pointsBalance={pointsBalance}
-        depositPointsEarned={depositPointsEarned}
-        onOpenAchievements={onOpenAchievements}
-      />
-    );
-  }
-
   return (
-    <Box className="liveSearch">
-      <Typography component="h3" variant="h4">
-        Ajoute une chanson à la boîte et gagne pleins de points
-      </Typography>
-
-      {errorMessage ? (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {errorMessage}
-        </Alert>
-      ) : null}
-
-      <Button variant="contained" onClick={openDrawer}>
-        Partager une chanson
-      </Button>
-
-      <Drawer
-        anchor="right"
-        open={drawerOpen}
-        onClose={() => closeDrawer()}
-        PaperProps={{
-          sx: {
-            width: "100vw",
-            maxWidth: "100vw",
-            height: "100vh",
-            overflow: "hidden",
-          },
-        }}
-      >
-        <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
-          <Box sx={{ p: 5, pb: 2 }}>
-            <Typography component="h2" variant="h3" sx={{ mb: 3 }}>
-              Choisis une chanson à partager
+    <Box ref={sectionAnchorRef} className="liveSearch_section_anchor">
+      {hasDeposit ? (
+        <MyDeposit
+          deposit={myDeposit}
+          successes={successes}
+          pointsBalance={pointsBalance}
+          depositPointsEarned={depositPointsEarned}
+          onOpenAchievements={onOpenAchievements}
+        />
+      ) : (
+        <Box
+          ref={liveSearchSlotRef}
+          className="liveSearch_slot"
+          style={isLiveSearchFixed && liveSearchHeight > 0 ? { minHeight: liveSearchHeight } : undefined}
+        >
+          <Box
+            ref={liveSearchCardRef}
+            className={`liveSearch${isLiveSearchFixed ? " fixed" : ""}`}
+          >
+            <Typography component="h3" variant="h4">
+              Ajoute une chanson à la boîte et gagne pleins de points
             </Typography>
+
+            {errorMessage ? (
+              <Alert severity="error" sx={{ mb: 2 }}>
+                {errorMessage}
+              </Alert>
+            ) : null}
+
+            <Button variant="contained" onClick={openDrawer}>
+              Partager une chanson
+            </Button>
+
+            <Drawer
+              anchor="right"
+              open={drawerOpen}
+              onClose={() => closeDrawer()}
+              PaperProps={{
+                sx: {
+                  width: "100vw",
+                  maxWidth: "100vw",
+                  height: "100vh",
+                  overflow: "hidden",
+                },
+              }}
+            >
+              <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
+                <Box sx={{ p: 5, pb: 2 }}>
+                  <Typography component="h2" variant="h3" sx={{ mb: 3 }}>
+                    Choisis une chanson à partager
+                  </Typography>
+                </Box>
+
+                {errorMessage ? (
+                  <Alert severity="error" sx={{ mx: 5, mb: 2 }}>
+                    {errorMessage}
+                  </Alert>
+                ) : null}
+
+                {drawerOpen ? (
+                  <SearchPanel
+                    inputRef={searchInputRef}
+                    onSelectSong={handleSongSelected}
+                    actionLabel="Partager"
+                    depositFlowState={depositFlowState}
+                    onDepositVisualComplete={handleDepositVisualComplete}
+                    rootSx={{ flex: 1, minHeight: 0 }}
+                    searchBarWrapperSx={{ px: 5, pb: 2 }}
+                    contentSx={{ overflowX: "hidden", overflowY: "scroll", flex: 1, pb: "96px" }}
+                  />
+                ) : null}
+              </Box>
+            </Drawer>
           </Box>
-
-          {errorMessage ? (
-            <Alert severity="error" sx={{ mx: 5, mb: 2 }}>
-              {errorMessage}
-            </Alert>
-          ) : null}
-
-          {drawerOpen ? (
-            <SearchPanel
-              inputRef={searchInputRef}
-              onSelectSong={handleSongSelected}
-              actionLabel="Partager"
-              depositFlowState={depositFlowState}
-              onDepositVisualComplete={handleDepositVisualComplete}
-              rootSx={{ flex: 1, minHeight: 0 }}
-              searchBarWrapperSx={{ px: 5, pb: 2 }}
-              contentSx={{ overflowX: "hidden", overflowY: "scroll", flex: 1, pb: "96px" }}
-            />
-          ) : null}
         </Box>
-      </Drawer>
+      )}
     </Box>
   );
 }

--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.js
@@ -278,7 +278,7 @@ export default function LiveSearchSection({
             className={`liveSearch${isLiveSearchFixed ? " fixed" : ""}`}
           >
             <Typography component="h3" variant="h5">
-              Ajoute une chanson à la boîte et gagne pleins de points
+              Ajoute une chanson à la boîte, gagne des points et découvre d'autres chansons
             </Typography>
 
             {errorMessage ? (

--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.js
@@ -271,7 +271,7 @@ export default function LiveSearchSection({
         <Box
           ref={liveSearchSlotRef}
           className="liveSearch_slot"
-          style={isLiveSearchFixed && liveSearchHeight > 0 ? { minHeight: liveSearchHeight } : undefined}
+          style={{ minHeight: liveSearchHeight }}
         >
           <Box
             ref={liveSearchCardRef}

--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.test.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 
@@ -8,6 +8,27 @@ import { FlowboxSessionContext } from '../runtime/FlowboxSessionContext';
 import LiveSearchSection from './LiveSearchSection';
 
 let mockLatestSearchPanelProps = null;
+let mockScrollIntoView = null;
+
+function getLiveSearchCard() {
+  return screen.getByRole('button', { name: 'Partager une chanson' }).closest('.liveSearch');
+}
+
+function mockLiveSearchRects({ getSlotTop = () => 24, cardHeight = 96 } = {}) {
+  jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function getBoundingClientRect() {
+    const slotTop = getSlotTop();
+
+    if (this.classList?.contains('liveSearch_slot')) {
+      return { top: slotTop, bottom: slotTop + cardHeight, height: cardHeight, left: 0, right: 320, width: 320 };
+    }
+
+    if (this.classList?.contains('liveSearch')) {
+      return { top: slotTop, bottom: slotTop + cardHeight, height: cardHeight, left: 0, right: 320, width: 320 };
+    }
+
+    return { top: 0, bottom: 0, height: 0, left: 0, right: 0, width: 0 };
+  });
+}
 
 jest.mock('../../Common/Search/SearchPanel', () => ({
   __esModule: true,
@@ -102,16 +123,64 @@ describe('LiveSearchSection', () => {
     jest.clearAllMocks();
     mockLatestSearchPanelProps = null;
     global.fetch = jest.fn();
+    mockScrollIntoView = jest.fn();
+    window.HTMLElement.prototype.scrollIntoView = mockScrollIntoView;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   test('shows a share CTA before deposit and opens the SearchPanel drawer through the URL', async () => {
     renderLiveSearchSection();
 
-    expect(screen.getByRole('heading', { name: /Partage une chanson/i, level: 3 })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Ajoute une chanson/i, level: 3 })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
 
     expect(await screen.findByText('Choisis une chanson à partager')).toBeInTheDocument();
     expect(screen.getByTestId('location-search')).toHaveTextContent('drawer=live-search');
+  });
+
+  test('adds the fixed class before deposit when the live search slot scrolls under the header', async () => {
+    let slotTop = 24;
+    mockLiveSearchRects({ getSlotTop: () => slotTop });
+
+    renderLiveSearchSection();
+
+    expect(screen.getByRole('button', { name: 'Partager une chanson' })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(getLiveSearchCard()).not.toHaveClass('fixed');
+    });
+
+    slotTop = -1;
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    await waitFor(() => {
+      expect(getLiveSearchCard()).toHaveClass('fixed');
+    });
+    expect(getLiveSearchCard().parentElement).toHaveStyle({ minHeight: '96px' });
+  });
+
+  test('removes the fixed class before deposit when scrolling back above the live search slot', async () => {
+    let slotTop = -1;
+    mockLiveSearchRects({ getSlotTop: () => slotTop });
+
+    renderLiveSearchSection();
+
+    await waitFor(() => {
+      expect(getLiveSearchCard()).toHaveClass('fixed');
+    });
+
+    slotTop = 24;
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    await waitFor(() => {
+      expect(getLiveSearchCard()).not.toHaveClass('fixed');
+    });
   });
 
   test('browser back closes the URL-driven drawer', async () => {
@@ -167,6 +236,7 @@ describe('LiveSearchSection', () => {
     expect(onDepositCreated).not.toHaveBeenCalled();
     expect(setUser).not.toHaveBeenCalled();
     expect(screen.getByText('Choisis une chanson à partager')).toBeInTheDocument();
+    expect(mockScrollIntoView).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Terminer animation' }));
 
@@ -184,6 +254,7 @@ describe('LiveSearchSection', () => {
     await waitFor(() => {
       expect(screen.queryByText('Choisis une chanson à partager')).not.toBeInTheDocument();
     });
+    expect(mockScrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
   });
 
   test('renders MyDeposit after deposit and does not allow opening search', () => {
@@ -195,6 +266,7 @@ describe('LiveSearchSection', () => {
     expect(screen.getByText('Chanson déposée avec succès')).toBeInTheDocument();
     expect(screen.getByText('Déjà déposée')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Partager une chanson' })).not.toBeInTheDocument();
+    expect(document.querySelector('.liveSearch.fixed')).not.toBeInTheDocument();
   });
 
   test('redirects to closed when the box session is required', async () => {


### PR DESCRIPTION
### Motivation
- Improve the UX of the Flowbox Discover deposit area so the pre-deposit LiveSearch card becomes visually fixed when scrolled under the app header, without JS injecting positioning styles. 
- Preserve layout flow (avoid content jump) while enabling a fixed visual state only before a deposit exists. 
- After a successful deposit visual flow, ensure the page scrolls smoothly to a stable anchor (section) only once the Drawer is closed.

### Description
- Add a stable anchor wrapper around the whole LiveSearch / MyDeposit slot (`.liveSearch_section_anchor`) and use it as the `scrollIntoView` target after deposit. (`frontend/src/components/Flowbox/discover/LiveSearchSection.js`).
- Implement a pre-deposit slot wrapper (`.liveSearch_slot`) and a measured placeholder `minHeight` to keep an in-flow space while the `.liveSearch` card toggles the `fixed` class; JS only measures height and toggles class, it does not set `top/left/right/z-index` values. (`LiveSearchSection.js`, `frontend/assets/scss/3-component/_box.scss`).
- Compute fixed-state by measuring `getBoundingClientRect()` of the slot and using the header bottom as limit (try `.MuiAppBar-root`/`header`, fallback to CSS var `--mm-app-header-height`). Listeners on `scroll` and `resize` update `isLiveSearchFixed`; state is forced false when `myDeposit` exists. (`LiveSearchSection.js`).
- After `onDepositVisualComplete`, mark a pending scroll, call `closeDrawer()` and wait for `drawerOpen === false` before calling `sectionAnchorRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })`. This prevents scrolling while the Drawer is open. (`LiveSearchSection.js`).
- Minimal SCSS additions: `.liveSearch_section_anchor { scroll-margin-top: var(--mm-app-header-height, 72px); }`, `.liveSearch_slot { position: relative; }`, `.liveSearch.fixed { position: fixed; }` so designers can tune exact `top/left/right/width/z-index` by hand later. (`frontend/assets/scss/3-component/_box.scss`).
- Tests updated/extended: `LiveSearchSection.test.js` now mocks `getBoundingClientRect` and `scrollIntoView` and asserts fixed-class toggling, placeholder height, no fixed state after deposit, and that `scrollIntoView` is called after Drawer closure; `Discover.test.js` mock adjusted to trigger `onDepositVisualComplete` after `onSelectSong` in the mocked `SearchPanel`. (`frontend/src/components/Flowbox/discover/LiveSearchSection.test.js`, `frontend/src/components/Flowbox/Discover.test.js`).

### Testing
- Ran targeted unit tests: `cd frontend && npm test -- --runInBand LiveSearchSection` — all tests passed (10/10). 
- Ran Discover tests: `cd frontend && npm test -- --runInBand Discover` — tests passed (Discover-related suites passed; total tests in flow passed). 
- Ran component ESLint checks for the touched files: `npx eslint src/components/Flowbox/discover/LiveSearchSection.js src/components/Flowbox/discover/LiveSearchSection.test.js src/components/Flowbox/Discover.test.js` — no errors, only a small number of warnings related to complexity/size. 
- Ran full `npm run lint` (repo-wide) which reports many pre-existing errors/warnings outside the modified Flowbox files; these are unrelated to this change. 
- Built production bundle: `cd frontend && npm run build` — build succeeded; webpack emitted performance-size warnings only.

Files modified:
- `frontend/src/components/Flowbox/discover/LiveSearchSection.js` (anchor, slot wrapper, fixed-state logic, post-deposit scroll handling)
- `frontend/assets/scss/3-component/_box.scss` (minimal classes: `.liveSearch_section_anchor`, `.liveSearch_slot`, `.liveSearch.fixed`)
- `frontend/src/components/Flowbox/discover/LiveSearchSection.test.js` (add tests for fixed behaviour and post-deposit scroll)
- `frontend/src/components/Flowbox/Discover.test.js` (mock adjustment to emulate visual completion flow)

Notes:
- SCSS intentionally keeps `position: fixed` minimal; designers should tune exact positioning values (`top`, `width`, `z-index`, safe-area) in a follow-up style pass if needed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf32ff490833280fbb2b40204d1bd)