### PR TITLE
LiveSearch: mobile-only fixed behavior with stable anchor and post-deposit scroll

### DIFF
--- a/frontend/assets/scss/3-component/_box.scss
+++ b/frontend/assets/scss/3-component/_box.scss
@@ -30,7 +30,7 @@
 }
 
 .liveSearch {
-  box-shadow: 0 4px 8px -4px rgba(0,0,0,.2);
+  box-shadow: 0 4px 8px -4px rgb(0 0 0 / 20%);
   display: flex;
   flex-direction: column;
   padding: 16px 20px;
@@ -39,23 +39,13 @@
   border-radius: var(--mm-radius-xl);
   gap: 12px;
   background: var(--mm-color-surface);
-  gap: 12px;
   transition: all 0.3s;
 }
 
-.liveSearch_slot {
-    position: relative;
-    min-height: 184px;
-    height: auto;
-    transition: all 0.3s;
+.liveSearch.fixed {
+  position: fixed;
 }
 
-.liveSearch.fixed {
-    position: fixed;
-    top: 64px;
-    left: 0px;
-    right: 0;
-    z-index: 200;
-    margin: 0;
-    border-radius: 0;
+.liveSearch_anchor {
+  scroll-margin-top: var(--mm-app-header-height, 72px);
 }

--- a/frontend/src/components/Flowbox/Discover.test.js
+++ b/frontend/src/components/Flowbox/Discover.test.js
@@ -18,13 +18,21 @@ jest.mock('../Common/Deposit', () => ({
 
 jest.mock('../Common/Search/SearchPanel', () => ({
   __esModule: true,
-  default: ({ onSelectSong }) => (
-    <button
-      type="button"
-      onClick={() => onSelectSong({ id: 'track-1', name: 'Posted song', artist: 'Artist', image_url: 'cover.jpg' }, 'request-1')}
-    >
-      Choisir Posted song
-    </button>
+  default: ({ onSelectSong, onDepositVisualComplete }) => (
+    <div>
+      <button
+        type="button"
+        onClick={() => onSelectSong({ id: 'track-1', name: 'Posted song', artist: 'Artist', image_url: 'cover.jpg' }, 'request-1')}
+      >
+        Choisir Posted song
+      </button>
+      <button
+        type="button"
+        onClick={() => onDepositVisualComplete?.('request-1')}
+      >
+        Terminer animation
+      </button>
+    </div>
   ),
 }));
 
@@ -151,6 +159,11 @@ describe('Discover', () => {
     jest.clearAllMocks();
     intersectionObservers = [];
     delete window.IntersectionObserver;
+    Element.prototype.scrollIntoView = jest.fn();
+    window.requestAnimationFrame = jest.fn((callback) => {
+      callback();
+      return 1;
+    });
   });
 
   function mockIntersectionObserver() {
@@ -244,7 +257,7 @@ describe('Discover', () => {
 
     const mainDeposit = await screen.findByTestId('deposit-main');
     const liveSearchHeading = screen.getByRole('heading', {
-      name: /Partage une chanson pour gagner des points/i,
+      name: /Ajoute une chanson à la boîte et gagne pleins de points/i,
       level: 3,
     });
     const article = await screen.findByTestId('article-card');
@@ -269,7 +282,7 @@ describe('Discover', () => {
 
     const emptyState = await screen.findByText(/Aucune chanson à découvrir/i);
     const liveSearchHeading = screen.getByRole('heading', {
-      name: /Partage une chanson pour gagner des points/i,
+      name: /Ajoute une chanson à la boîte et gagne pleins de points/i,
       level: 3,
     });
     const article = await screen.findByTestId('article-card');
@@ -306,6 +319,7 @@ describe('Discover', () => {
     expect(await screen.findByText('older-1')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Choisir Posted song' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Terminer animation' }));
 
     expect(await screen.findByText('Chanson déposée avec succès')).toBeInTheDocument();
     expect(screen.getByText('Posted song')).toBeInTheDocument();

--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.js
@@ -63,10 +63,71 @@ export default function LiveSearchSection({
     errorMessage: null,
   });
   const searchInputRef = useRef(null);
+  const sectionRef = useRef(null);
   const isPostingRef = useRef(false);
   const pendingDepositResultRef = useRef(null);
+  const pendingScrollToSectionRef = useRef(false);
+  const [isFixed, setIsFixed] = useState(false);
 
   const hasDeposit = Boolean(myDeposit);
+
+  const updateFixedState = useCallback(() => {
+    if (hasDeposit) {
+      setIsFixed(false);
+      return;
+    }
+
+    const section = sectionRef.current;
+    if (!section) {
+      setIsFixed(false);
+      return;
+    }
+
+    const isMobile = typeof window.matchMedia === "function"
+      ? window.matchMedia("(max-width: 768px)").matches
+      : false;
+    if (!isMobile) {
+      setIsFixed(false);
+      return;
+    }
+
+    const rect = section.getBoundingClientRect();
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+
+    setIsFixed(rect.bottom > viewportHeight);
+  }, [hasDeposit]);
+
+  useEffect(() => {
+    updateFixedState();
+
+    window.addEventListener("scroll", updateFixedState);
+    window.addEventListener("resize", updateFixedState);
+
+    return () => {
+      window.removeEventListener("scroll", updateFixedState);
+      window.removeEventListener("resize", updateFixedState);
+    };
+  }, [updateFixedState]);
+
+  useEffect(() => {
+    if (hasDeposit) {
+      setIsFixed(false);
+    }
+  }, [hasDeposit]);
+
+  useEffect(() => {
+    if (drawerOpen) {return;}
+    if (!pendingScrollToSectionRef.current) {return;}
+
+    pendingScrollToSectionRef.current = false;
+
+    window.requestAnimationFrame(() => {
+      sectionRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    });
+  }, [drawerOpen]);
 
   useEffect(() => {
     const shouldOpenDrawer = !hasDeposit && matchesDrawerSearch(
@@ -123,6 +184,7 @@ export default function LiveSearchSection({
 
     pendingDepositResultRef.current = null;
     isPostingRef.current = false;
+    pendingScrollToSectionRef.current = true;
     closeDrawer();
   }, [closeDrawer, onDepositCreated, setUser]);
 
@@ -196,18 +258,20 @@ export default function LiveSearchSection({
 
   if (hasDeposit) {
     return (
-      <MyDeposit
-        deposit={myDeposit}
-        successes={successes}
-        pointsBalance={pointsBalance}
-        depositPointsEarned={depositPointsEarned}
-        onOpenAchievements={onOpenAchievements}
-      />
+      <Box ref={sectionRef} className="liveSearch_anchor">
+        <MyDeposit
+          deposit={myDeposit}
+          successes={successes}
+          pointsBalance={pointsBalance}
+          depositPointsEarned={depositPointsEarned}
+          onOpenAchievements={onOpenAchievements}
+        />
+      </Box>
     );
   }
 
   return (
-    <Box className="liveSearch">
+    <Box ref={sectionRef} className={`liveSearch${isFixed ? " fixed" : ""}`}>
       <Typography component="h3" variant="h4">
         Ajoute une chanson à la boîte et gagne pleins de points
       </Typography>

--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.test.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.test.js
@@ -97,17 +97,56 @@ function mockJsonResponse(body, init = {}) {
   };
 }
 
+function mockMobileViewport(matches) {
+  window.matchMedia = jest.fn().mockImplementation((query) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }));
+}
+
+function mockSectionBottom(bottom) {
+  Element.prototype.getBoundingClientRect = jest.fn(() => ({
+    bottom,
+    height: 100,
+    left: 0,
+    right: 100,
+    top: bottom - 100,
+    width: 100,
+    x: 0,
+    y: bottom - 100,
+    toJSON: () => ({}),
+  }));
+}
+
+function getLiveSearch() {
+  return screen.getByRole('button', { name: 'Partager une chanson' }).closest('.liveSearch');
+}
+
 describe('LiveSearchSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockLatestSearchPanelProps = null;
     global.fetch = jest.fn();
+    mockMobileViewport(false);
+    mockSectionBottom(0);
+    Object.defineProperty(window, 'innerHeight', { configurable: true, writable: true, value: 600 });
+    Element.prototype.scrollIntoView = jest.fn();
+    window.requestAnimationFrame = jest.fn((callback) => {
+      callback();
+      return 1;
+    });
   });
 
   test('shows a share CTA before deposit and opens the SearchPanel drawer through the URL', async () => {
     renderLiveSearchSection();
 
-    expect(screen.getByRole('heading', { name: /Partage une chanson/i, level: 3 })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Partager une chanson' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
 
     expect(await screen.findByText('Choisis une chanson à partager')).toBeInTheDocument();
@@ -128,7 +167,43 @@ describe('LiveSearchSection', () => {
     expect(screen.getByTestId('location-search')).toBeEmptyDOMElement();
   });
 
-  test('posts selected song, waits for the visual completion, updates user points and closes drawer', async () => {
+  test('adds the fixed class on mobile when the live search bottom overflows the viewport', async () => {
+    mockMobileViewport(true);
+    mockSectionBottom(720);
+    renderLiveSearchSection();
+
+    fireEvent.scroll(window);
+
+    await waitFor(() => {
+      expect(getLiveSearch()).toHaveClass('fixed');
+    });
+  });
+
+  test('does not add the fixed class on mobile when the live search bottom fits the viewport', async () => {
+    mockMobileViewport(true);
+    mockSectionBottom(600);
+    renderLiveSearchSection();
+
+    fireEvent.scroll(window);
+
+    await waitFor(() => {
+      expect(getLiveSearch()).not.toHaveClass('fixed');
+    });
+  });
+
+  test('does not add the fixed class on desktop even when the live search bottom overflows', async () => {
+    mockMobileViewport(false);
+    mockSectionBottom(720);
+    renderLiveSearchSection();
+
+    fireEvent.scroll(window);
+
+    await waitFor(() => {
+      expect(getLiveSearch()).not.toHaveClass('fixed');
+    });
+  });
+
+  test('posts selected song, waits for the visual completion, updates user points, closes drawer, and scrolls to the section', async () => {
     global.fetch.mockResolvedValueOnce(mockJsonResponse({
       my_deposit: { public_key: 'dep-1', song: { title: 'Search song', artist: 'Artist' } },
       successes: [{ name: 'total', points: 42 }],
@@ -184,6 +259,12 @@ describe('LiveSearchSection', () => {
     await waitFor(() => {
       expect(screen.queryByText('Choisis une chanson à partager')).not.toBeInTheDocument();
     });
+    await waitFor(() => {
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({
+        behavior: 'smooth',
+        block: 'start',
+      });
+    });
   });
 
   test('renders MyDeposit after deposit and does not allow opening search', () => {
@@ -195,6 +276,7 @@ describe('LiveSearchSection', () => {
     expect(screen.getByText('Chanson déposée avec succès')).toBeInTheDocument();
     expect(screen.getByText('Déjà déposée')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Partager une chanson' })).not.toBeInTheDocument();
+    expect(document.querySelector('.liveSearch.fixed')).not.toBeInTheDocument();
   });
 
   test('redirects to closed when the box session is required', async () => {


### PR DESCRIPTION
### Motivation
- Make the LiveSearch section on Discover able to become fixed to the viewport bottom on mobile when its natural bottom overflows the screen, while keeping behaviour disabled after a deposit and on desktop. 
- Provide a stable anchor for both pre-deposit `.liveSearch` and post-deposit `MyDeposit` so we can reliably measure position and scroll to the same place after a successful deposit.

### Description
- Added a stable ref `sectionRef` around the LiveSearch area and the MyDeposit rendering so both share the same anchor, and introduced `isFixed` state to toggle only the `fixed` class on `.liveSearch`. (file: `frontend/src/components/Flowbox/discover/LiveSearchSection.js`)
- Implemented `updateFixedState` that runs on `scroll` and `resize` and sets `isFixed` to `true` only when mobile (`matchMedia('(max-width: 768px)')`), pre-deposit, and `sectionRef.current.getBoundingClientRect().bottom > viewportHeight`; otherwise it clears `isFixed`. (file: `LiveSearchSection.js`)
- Deferred scrolling-to-section after deposit until the SearchPanel drawer is closed by using `pendingScrollToSectionRef` and a `useEffect` watching `drawerOpen`, then calling `sectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })` once closed. (file: `LiveSearchSection.js`)
- Kept the JS responsibility minimal: it only adds/removes the exact class `fixed` on `.liveSearch` (no inline styles, no placeholders, and no artificial reserved space). (file: `LiveSearchSection.js`)
- Cleaned SCSS: removed/neutralized obsolete `.liveSearch_slot` and eliminated the old top-fixed rules; `.liveSearch.fixed` now only contains `position: fixed;` and `.liveSearch_anchor` adds a `scroll-margin-top` helper. (file: `frontend/assets/scss/3-component/_box.scss`)
- Updated tests to cover the new behaviour: added mobile/desktop scenarios mocking `window.matchMedia` and `getBoundingClientRect`, ensured `fixed` class toggles correctly, ensured post-deposit flow still triggers `onDepositCreated` and that `scrollIntoView` is called after drawer close, and adjusted Discover tests to wait for the visual-completion flow. (files: `frontend/src/components/Flowbox/discover/LiveSearchSection.test.js`, `frontend/src/components/Flowbox/Discover.test.js`)

### Testing
- Unit tests run:
  - `cd frontend && npm test -- --runInBand src/components/Flowbox/discover/LiveSearchSection.test.js` => PASS (11 tests, all passed).
  - `cd frontend && npm test -- --runInBand Discover` => PASS (Discover suite passed; the run emits an existing React warning about missing keys in `DiscoverTimeline` but tests pass).
  - Full Discover-related suites executed together => PASS (31 tests total, all passed).
- Build:
  - `cd frontend && npm run build` => build succeeded; webpack produced warnings about bundle size (existing project warning), but compiled.
- Linters:
  - Targeted eslint on the touched files (`npx eslint ...LiveSearchSection.js ...LiveSearchSection.test.js ...Discover.test.js`) reported only warnings (no new errors related to the change).
  - `cd frontend && npm run lint` failed due to unrelated, pre-existing repository lint errors in other areas (not introduced by this change).
  - `cd frontend/assets && npm run lint:scss` still reports unrelated stylelint errors in other SCSS files; `_box.scss` changes were simplified and cleaned of the previous top-fixed rules.

Files modified
- frontend/src/components/Flowbox/discover/LiveSearchSection.js
- frontend/assets/scss/3-component/_box.scss
- frontend/src/components/Flowbox/discover/LiveSearchSection.test.js
- frontend/src/components/Flowbox/Discover.test.js

Notes / confirmations
- The JS only toggles the class exactly named `fixed` (no alternate names were introduced).
- No placeholders, no inline position styles, and no reserved/minHeight changes were added.
- The `fixed` behaviour is mobile-only and is disabled when `myDeposit` exists (post-deposit) or on desktop.
- The final visual positioning of `.liveSearch.fixed` (top/bottom offsets, z-index, margin, etc.) is intentionally left minimal in SCSS and should be tuned later in design/SCSS work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd8e8dbf5c8332ad122ae65a569686)