### PR TITLE
Make LiveSearch fixed before deposit

### DIFF
--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.js
@@ -22,6 +22,13 @@ const LIVE_SEARCH_DRAWER_PARAM = "drawer";
 const LIVE_SEARCH_DRAWER_VALUE = "live-search";
 const DEFAULT_ERROR_MESSAGE = "Impossible de partager cette chanson pour le moment.";
 const ALREADY_EXISTS_MESSAGE = "Tu as déjà partagé une chanson dans cette session.";
+const HEADER_SELECTOR = ".MuiAppBar-root, header";
+
+function getHeaderOffset() {
+  if (typeof document === "undefined") {return 0;}
+  const header = document.querySelector(HEADER_SELECTOR);
+  return header?.getBoundingClientRect?.().height || 0;
+}
 
 function normalizeDepositResponse(data) {
   return {
@@ -62,11 +69,111 @@ export default function LiveSearchSection({
     status: "idle",
     errorMessage: null,
   });
+  const [isFixed, setIsFixed] = useState(false);
+  const [depositSucceeded, setDepositSucceeded] = useState(false);
+  const [liveSearchHeight, setLiveSearchHeight] = useState(0);
+  const [headerOffset, setHeaderOffset] = useState(0);
+  const placeholderRef = useRef(null);
+  const liveSearchRef = useRef(null);
   const searchInputRef = useRef(null);
   const isPostingRef = useRef(false);
   const pendingDepositResultRef = useRef(null);
+  const isFixedRef = useRef(false);
 
   const hasDeposit = Boolean(myDeposit);
+  const isPreDeposit = !hasDeposit && !depositSucceeded;
+
+  const scrollToPlaceholder = useCallback(() => {
+    placeholderRef.current?.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+    });
+  }, []);
+
+  const measureLiveSearchHeight = useCallback(() => {
+    const nextHeight = liveSearchRef.current?.getBoundingClientRect?.().height || 0;
+    setLiveSearchHeight((currentHeight) => (
+      currentHeight === nextHeight ? currentHeight : nextHeight
+    ));
+  }, []);
+
+  useEffect(() => {
+    isFixedRef.current = isFixed;
+  }, [isFixed]);
+
+  useEffect(() => {
+    if (!isPreDeposit && isFixedRef.current) {
+      setIsFixed(false);
+    }
+  }, [isPreDeposit]);
+
+  useEffect(() => {
+    measureLiveSearchHeight();
+    const liveSearchNode = liveSearchRef.current;
+
+    if (!liveSearchNode || typeof ResizeObserver === "undefined") {
+      return undefined;
+    }
+
+    const resizeObserver = new ResizeObserver(() => {
+      measureLiveSearchHeight();
+    });
+    resizeObserver.observe(liveSearchNode);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [measureLiveSearchHeight]);
+
+  useEffect(() => {
+    let animationFrame = null;
+
+    const updateFixedState = () => {
+      animationFrame = null;
+      const nextHeaderOffset = getHeaderOffset();
+      setHeaderOffset((currentOffset) => (
+        currentOffset === nextHeaderOffset ? currentOffset : nextHeaderOffset
+      ));
+
+      if (!isPreDeposit || !placeholderRef.current) {
+        if (isFixedRef.current) {
+          setIsFixed(false);
+        }
+        return;
+      }
+
+      measureLiveSearchHeight();
+      const placeholderTop = placeholderRef.current.getBoundingClientRect().top;
+      const shouldBeFixed = placeholderTop <= nextHeaderOffset;
+      if (isFixedRef.current !== shouldBeFixed) {
+        setIsFixed(shouldBeFixed);
+      }
+    };
+
+    const scheduleFixedStateUpdate = () => {
+      if (animationFrame !== null) {return;}
+      animationFrame = window.requestAnimationFrame(updateFixedState);
+    };
+
+    scheduleFixedStateUpdate();
+    window.addEventListener("scroll", scheduleFixedStateUpdate, { passive: true });
+    window.addEventListener("resize", scheduleFixedStateUpdate);
+
+    const headerNode = document.querySelector(HEADER_SELECTOR);
+    const headerResizeObserver = headerNode && typeof ResizeObserver !== "undefined"
+      ? new ResizeObserver(scheduleFixedStateUpdate)
+      : null;
+    headerResizeObserver?.observe(headerNode);
+
+    return () => {
+      if (animationFrame !== null) {
+        window.cancelAnimationFrame(animationFrame);
+      }
+      headerResizeObserver?.disconnect();
+      window.removeEventListener("scroll", scheduleFixedStateUpdate);
+      window.removeEventListener("resize", scheduleFixedStateUpdate);
+    };
+  }, [isPreDeposit, measureLiveSearchHeight]);
 
   useEffect(() => {
     const shouldOpenDrawer = !hasDeposit && matchesDrawerSearch(
@@ -89,7 +196,9 @@ export default function LiveSearchSection({
     if (!closedByHistory) {
       setDrawerOpen(false);
     }
-  }, [location, navigate]);
+
+    scrollToPlaceholder();
+  }, [location, navigate, scrollToPlaceholder]);
 
   useEffect(() => {
     if (!hasDeposit) {return;}
@@ -98,7 +207,7 @@ export default function LiveSearchSection({
   }, [closeDrawer, hasDeposit, location]);
 
   const openDrawer = useCallback(() => {
-    if (hasDeposit) {return;}
+    if (!isPreDeposit) {return;}
     pendingDepositResultRef.current = null;
     setErrorMessage("");
     openDrawerWithHistory({
@@ -107,7 +216,7 @@ export default function LiveSearchSection({
       param: LIVE_SEARCH_DRAWER_PARAM,
       value: LIVE_SEARCH_DRAWER_VALUE,
     });
-  }, [hasDeposit, location, navigate]);
+  }, [isPreDeposit, location, navigate]);
 
   const handleDepositVisualComplete = useCallback((requestKey = null) => {
     const pendingDepositResult = pendingDepositResultRef.current;
@@ -138,7 +247,7 @@ export default function LiveSearchSection({
   }, [boxSlug, clearBoxSession, navigate]);
 
   const handleSongSelected = useCallback(async (option, requestKey = null) => {
-    if (hasDeposit || isPostingRef.current) {return;}
+    if (!isPreDeposit || isPostingRef.current) {return;}
     isPostingRef.current = true;
     setErrorMessage("");
     setDepositFlowState({ requestKey, status: "pending", errorMessage: null });
@@ -166,6 +275,8 @@ export default function LiveSearchSection({
           hasDepositResyncPayload(data)
         ) {
           const normalized = normalizeDepositResponse(data);
+          setDepositSucceeded(true);
+          setIsFixed(false);
           pendingDepositResultRef.current = { requestKey, normalized };
           setDepositFlowState({ requestKey, status: "success", errorMessage: null });
           return;
@@ -184,6 +295,8 @@ export default function LiveSearchSection({
       }
 
       const normalized = normalizeDepositResponse(data);
+      setDepositSucceeded(true);
+      setIsFixed(false);
       pendingDepositResultRef.current = { requestKey, normalized };
       setDepositFlowState({ requestKey, status: "success", errorMessage: null });
     } catch (error) {
@@ -192,7 +305,7 @@ export default function LiveSearchSection({
       setDepositFlowState({ requestKey, status: "error", errorMessage: message });
       isPostingRef.current = false;
     }
-  }, [boxSlug, handleDepositError, hasDeposit]);
+  }, [boxSlug, handleDepositError, isPreDeposit]);
 
   if (hasDeposit) {
     return (
@@ -207,61 +320,70 @@ export default function LiveSearchSection({
   }
 
   return (
-    <Box className="liveSearch">
-      <Typography component="h3" variant="h4">
-        Ajoute une chanson à la boîte et gagne pleins de points
-      </Typography>
-
-      {errorMessage ? (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {errorMessage}
-        </Alert>
-      ) : null}
-
-      <Button variant="contained" onClick={openDrawer}>
-        Partager une chanson
-      </Button>
-
-      <Drawer
-        anchor="right"
-        open={drawerOpen}
-        onClose={() => closeDrawer()}
-        PaperProps={{
-          sx: {
-            width: "100vw",
-            maxWidth: "100vw",
-            height: "100vh",
-            overflow: "hidden",
-          },
-        }}
+    <Box
+      ref={placeholderRef}
+      sx={isFixed ? { height: `${liveSearchHeight}px` } : undefined}
+    >
+      <Box
+        ref={liveSearchRef}
+        className={`liveSearch${isFixed ? " fixed" : ""}`}
+        style={isFixed ? { top: `${headerOffset}px` } : undefined}
       >
-        <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
-          <Box sx={{ p: 5, pb: 2 }}>
-            <Typography component="h2" variant="h3" sx={{ mb: 3 }}>
-              Choisis une chanson à partager
-            </Typography>
+        <Typography component="h3" variant="h4">
+          Ajoute une chanson à la boîte et gagne pleins de points
+        </Typography>
+
+        {errorMessage ? (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {errorMessage}
+          </Alert>
+        ) : null}
+
+        <Button variant="contained" onClick={openDrawer}>
+          Partager une chanson
+        </Button>
+
+        <Drawer
+          anchor="right"
+          open={drawerOpen}
+          onClose={() => closeDrawer()}
+          PaperProps={{
+            sx: {
+              width: "100vw",
+              maxWidth: "100vw",
+              height: "100vh",
+              overflow: "hidden",
+            },
+          }}
+        >
+          <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
+            <Box sx={{ p: 5, pb: 2 }}>
+              <Typography component="h2" variant="h3" sx={{ mb: 3 }}>
+                Choisis une chanson à partager
+              </Typography>
+            </Box>
+
+            {errorMessage ? (
+              <Alert severity="error" sx={{ mx: 5, mb: 2 }}>
+                {errorMessage}
+              </Alert>
+            ) : null}
+
+            {drawerOpen ? (
+              <SearchPanel
+                inputRef={searchInputRef}
+                onSelectSong={handleSongSelected}
+                actionLabel="Partager"
+                depositFlowState={depositFlowState}
+                onDepositVisualComplete={handleDepositVisualComplete}
+                rootSx={{ flex: 1, minHeight: 0 }}
+                searchBarWrapperSx={{ px: 5, pb: 2 }}
+                contentSx={{ overflowX: "hidden", overflowY: "scroll", flex: 1, pb: "96px" }}
+              />
+            ) : null}
           </Box>
-
-          {errorMessage ? (
-            <Alert severity="error" sx={{ mx: 5, mb: 2 }}>
-              {errorMessage}
-            </Alert>
-          ) : null}
-
-          {drawerOpen ? (
-            <SearchPanel
-              inputRef={searchInputRef}
-              onSelectSong={handleSongSelected}
-              actionLabel="Partager"
-              depositFlowState={depositFlowState}
-              onDepositVisualComplete={handleDepositVisualComplete}
-              rootSx={{ flex: 1, minHeight: 0 }}
-              searchBarWrapperSx={{ px: 5, pb: 2 }}
-              contentSx={{ overflowX: "hidden", overflowY: "scroll", flex: 1, pb: "96px" }}
-            />
-          ) : null}
-        </Box>
-      </Drawer>
+        </Drawer>
+      </Box>
     </Box>
   );
 }

--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.test.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.test.js
@@ -102,12 +102,15 @@ describe('LiveSearchSection', () => {
     jest.clearAllMocks();
     mockLatestSearchPanelProps = null;
     global.fetch = jest.fn();
+    Element.prototype.scrollIntoView = jest.fn();
+    window.requestAnimationFrame = window.requestAnimationFrame || ((callback) => setTimeout(callback, 0));
+    window.cancelAnimationFrame = window.cancelAnimationFrame || ((id) => clearTimeout(id));
   });
 
   test('shows a share CTA before deposit and opens the SearchPanel drawer through the URL', async () => {
     renderLiveSearchSection();
 
-    expect(screen.getByRole('heading', { name: /Partage une chanson/i, level: 3 })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Ajoute une chanson/i, level: 3 })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
 
     expect(await screen.findByText('Choisis une chanson à partager')).toBeInTheDocument();
@@ -266,6 +269,64 @@ describe('LiveSearchSection', () => {
     await waitFor(() => {
       expect(screen.queryByText('Choisis une chanson à partager')).not.toBeInTheDocument();
     });
+  });
+
+
+  test('fixes LiveSearch under the measured header only before deposit', async () => {
+    const header = document.createElement('header');
+    header.getBoundingClientRect = jest.fn(() => ({ height: 64, top: 0, bottom: 64 }));
+    document.body.appendChild(header);
+
+    const { container } = renderLiveSearchSection();
+    const liveSearch = container.querySelector('.liveSearch');
+    const placeholder = liveSearch.parentElement;
+    liveSearch.getBoundingClientRect = jest.fn(() => ({ height: 120, top: 64, bottom: 184 }));
+    placeholder.getBoundingClientRect = jest.fn(() => ({ top: 60, bottom: 180 }));
+
+    fireEvent.scroll(window);
+
+    await waitFor(() => {
+      expect(liveSearch).toHaveClass('fixed');
+    });
+    expect(liveSearch).toHaveStyle({ top: '64px' });
+    expect(placeholder).toHaveStyle({ height: '120px' });
+
+    header.remove();
+  });
+
+  test('removes fixed mode after the deposit API succeeds', async () => {
+    const header = document.createElement('header');
+    header.getBoundingClientRect = jest.fn(() => ({ height: 64, top: 0, bottom: 64 }));
+    document.body.appendChild(header);
+
+    global.fetch.mockResolvedValueOnce(mockJsonResponse({
+      my_deposit: { public_key: 'dep-1', song: { title: 'Search song', artist: 'Artist' } },
+      successes: [],
+      points_balance: 5060,
+      deposit_points_earned: 0,
+    }));
+
+    const { container } = renderLiveSearchSection();
+    const liveSearch = container.querySelector('.liveSearch');
+    const placeholder = liveSearch.parentElement;
+    liveSearch.getBoundingClientRect = jest.fn(() => ({ height: 120, top: 64, bottom: 184 }));
+    placeholder.getBoundingClientRect = jest.fn(() => ({ top: 60, bottom: 180 }));
+
+    fireEvent.scroll(window);
+    await waitFor(() => {
+      expect(liveSearch).toHaveClass('fixed');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Choisir Search song' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('deposit-flow-status')).toHaveTextContent('success');
+    });
+    expect(liveSearch).not.toHaveClass('fixed');
+    expect(placeholder).not.toHaveStyle({ height: '120px' });
+
+    header.remove();
   });
 
   test('shows a MUI error surface for network errors', async () => {


### PR DESCRIPTION
### Motivation
- Ensure the LiveSearch section on Flowbox Discover remains accessible while the user is in pre-deposit mode by making it become fixed under the header when scrolled under the menu. 
- Make the `top` and reserved placeholder height dynamic because the header size and LiveSearch size can change at runtime. 
- Keep drawer behaviour unchanged (fixed can remain behind the drawer) and remove fixed mode only after a confirmed successful deposit.

### Description
- Added dynamic header measurement with `HEADER_SELECTOR = ".MuiAppBar-root, header"` and `getHeaderOffset()` to compute the `top` value used when `fixed`.  
- Wrapped the existing LiveSearch markup in a placeholder `Box` (`placeholderRef`) and an inner `Box` (`liveSearchRef`), adding only the `fixed` class when required and injecting inline `style={{ top: ... }}` while fixed.  
- Measure LiveSearch height with a `ResizeObserver` (fallback to `getBoundingClientRect`) and reserve that height on the placeholder when `isFixed` to avoid layout jumps.  
- Track pre-deposit state with `isPreDeposit` (derived from `myDeposit` and an internal `depositSucceeded` flag) so fixed mode only runs while pre-deposit.  
- Use `requestAnimationFrame` throttling for scroll/resize checks and attach a `ResizeObserver` on the header when available so `top` updates when the header changes size.  
- On confirmed deposit success (normal flow or resync conflict payload), set `depositSucceeded` and call `setIsFixed(false)` to remove fixed mode.  
- On drawer close, scroll to the placeholder using the exact call: `placeholderRef.current?.scrollIntoView({ behavior: "smooth", block: "center" })`.  
- Tests added/updated to verify fixed activation under a measured header and removal of fixed mode after deposit success.  
- Files modified: `frontend/src/components/Flowbox/discover/LiveSearchSection.js`, `frontend/src/components/Flowbox/discover/LiveSearchSection.test.js`.

### Testing
- Ran unit tests: `cd frontend && npm test -- LiveSearchSection.test.js --runInBand` — all tests passed (`10 passed`).  
- Ran targeted eslint on changed files: `cd frontend && npx eslint src/components/Flowbox/discover/LiveSearchSection.js src/components/Flowbox/discover/LiveSearchSection.test.js` — passed with warnings only for complexity/length rules.  
- Ran full lint: `cd frontend && npm run lint` — failed due to pre-existing, unrelated repo-wide lint issues (outside modified files).  
- Built production bundle: `cd frontend && npm run build` — build succeeded (webpack produced bundle with performance size warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fda0ac15e48332b7c025c55f0b2d2a)