### PR TITLE
Make Flowbox LiveSearch sticky before deposit

### DIFF
--- a/frontend/assets/scss/3-component/_box.scss
+++ b/frontend/assets/scss/3-component/_box.scss
@@ -40,12 +40,15 @@
   background: var(--mm-color-surface);
   transition: all 0.2s;
   top: 0px;
+  box-shadow: rgba(0, 0, 0, 0.0) 0px 4px 8px -4px;
+
 }
 
 
 
 .liveSearch.fixed {
-    position: fixed;
+  position: fixed;
+  box-shadow: rgba(0, 0, 0, 0.2) 0px 4px 8px -4px;
 }
 
 .liveSearchPlaceholder{

--- a/frontend/assets/scss/3-component/_box.scss
+++ b/frontend/assets/scss/3-component/_box.scss
@@ -31,14 +31,18 @@
 
 
 .liveSearch {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    padding: 16px 20px 6px 20px;
-    gap: 12px;
-    z-index: 200;
-    background: var(--mm-color-surface);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: 16px 20px 6px 20px;
+  gap: 12px;
+  z-index: 200;
+  background: var(--mm-color-surface);
+  transition: all 0.2s;
+  top: 0px;
 }
+
+
 
 .liveSearch.fixed {
     position: fixed;

--- a/frontend/assets/scss/3-component/_box.scss
+++ b/frontend/assets/scss/3-component/_box.scss
@@ -28,3 +28,18 @@
 .info_box.icon_container {
   padding: 16px;
 }
+
+
+.liveSearch {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    padding: 20px;
+    gap: 6px;
+    z-index: 200;
+    background: var(--mm-color-surface);
+}
+
+.liveSearch.fixed {
+    position: fixed;
+}

--- a/frontend/assets/scss/3-component/_box.scss
+++ b/frontend/assets/scss/3-component/_box.scss
@@ -34,12 +34,16 @@
     position: relative;
     display: flex;
     flex-direction: column;
-    padding: 20px;
-    gap: 6px;
+    padding: 16px 20px 6px 20px;
+    gap: 12px;
     z-index: 200;
     background: var(--mm-color-surface);
 }
 
 .liveSearch.fixed {
     position: fixed;
+}
+
+.liveSearchPlaceholder{
+  margin: 26px 0;
 }

--- a/frontend/assets/scss/3-component/_box.scss
+++ b/frontend/assets/scss/3-component/_box.scss
@@ -46,4 +46,5 @@
 
 .liveSearchPlaceholder{
   margin: 26px 0;
+  transition: all 0.2s;
 }

--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.js
@@ -313,7 +313,7 @@ export default function LiveSearchSection({
         className={liveSearchClassName}
         style={liveSearchStyle}
       >
-        <Typography component="h3" variant="h4">
+        <Typography component="h5" variant="h5">
           Ajoute une chanson à la boîte pour gagner des points et révéler plus de chansons
         </Typography>
 

--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.js
@@ -314,7 +314,7 @@ export default function LiveSearchSection({
         style={liveSearchStyle}
       >
         <Typography component="h3" variant="h4">
-          Ajoute une chanson à la boîte et gagne pleins de points
+          Ajoute une chanson à la boîte pour gagner des points et révéler plus de chansons
         </Typography>
 
         {errorMessage ? (

--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.js
@@ -22,6 +22,13 @@ const LIVE_SEARCH_DRAWER_PARAM = "drawer";
 const LIVE_SEARCH_DRAWER_VALUE = "live-search";
 const DEFAULT_ERROR_MESSAGE = "Impossible de partager cette chanson pour le moment.";
 const ALREADY_EXISTS_MESSAGE = "Tu as déjà partagé une chanson dans cette session.";
+const HEADER_SELECTOR = ".MuiAppBar-root, header";
+
+function getHeaderOffset() {
+  if (typeof document === "undefined") {return 0;}
+  const header = document.querySelector(HEADER_SELECTOR);
+  return header?.getBoundingClientRect?.().height || 0;
+}
 
 function normalizeDepositResponse(data) {
   return {
@@ -62,11 +69,96 @@ export default function LiveSearchSection({
     status: "idle",
     errorMessage: null,
   });
+  const [isFixed, setIsFixed] = useState(false);
+  const [liveSearchHeight, setLiveSearchHeight] = useState(0);
+  const [headerOffset, setHeaderOffset] = useState(0);
+  const placeholderRef = useRef(null);
+  const liveSearchRef = useRef(null);
   const searchInputRef = useRef(null);
   const isPostingRef = useRef(false);
   const pendingDepositResultRef = useRef(null);
+  const previousDrawerOpenRef = useRef(false);
 
   const hasDeposit = Boolean(myDeposit);
+  const isPreDeposit = !hasDeposit && depositFlowState.status !== "success";
+
+  const measureLiveSearchHeight = useCallback(() => {
+    const height = liveSearchRef.current?.getBoundingClientRect?.().height || 0;
+    setLiveSearchHeight((previousHeight) => (previousHeight === height ? previousHeight : height));
+  }, []);
+
+  const updateFixedState = useCallback(() => {
+    const nextHeaderOffset = getHeaderOffset();
+    setHeaderOffset((previousOffset) => (previousOffset === nextHeaderOffset ? previousOffset : nextHeaderOffset));
+
+    if (!isPreDeposit || !placeholderRef.current) {
+      setIsFixed((previousFixed) => (previousFixed ? false : previousFixed));
+      return;
+    }
+
+    const placeholderTop = placeholderRef.current.getBoundingClientRect().top;
+    const shouldBeFixed = placeholderTop <= nextHeaderOffset;
+    setIsFixed((previousFixed) => (previousFixed === shouldBeFixed ? previousFixed : shouldBeFixed));
+  }, [isPreDeposit]);
+
+  useEffect(() => {
+    measureLiveSearchHeight();
+
+    const liveSearchElement = liveSearchRef.current;
+    if (!liveSearchElement) {return undefined;}
+    if (typeof ResizeObserver === "undefined") {return undefined;}
+
+    const observer = new ResizeObserver(measureLiveSearchHeight);
+    observer.observe(liveSearchElement);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [isPreDeposit, measureLiveSearchHeight]);
+
+  useEffect(() => {
+    let animationFrameId = null;
+
+    const scheduleUpdate = () => {
+      if (animationFrameId !== null) {return;}
+      animationFrameId = window.requestAnimationFrame(() => {
+        animationFrameId = null;
+        measureLiveSearchHeight();
+        updateFixedState();
+      });
+    };
+
+    scheduleUpdate();
+    window.addEventListener("scroll", scheduleUpdate, { passive: true });
+    window.addEventListener("resize", scheduleUpdate);
+
+    return () => {
+      window.removeEventListener("scroll", scheduleUpdate);
+      window.removeEventListener("resize", scheduleUpdate);
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+    };
+  }, [measureLiveSearchHeight, updateFixedState]);
+
+  useEffect(() => {
+    if (isPreDeposit) {return;}
+    setIsFixed((previousFixed) => (previousFixed ? false : previousFixed));
+  }, [isPreDeposit]);
+
+  const scrollToPlaceholder = useCallback(() => {
+    placeholderRef.current?.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+    });
+  }, []);
+
+  useEffect(() => {
+    if (previousDrawerOpenRef.current && !drawerOpen) {
+      scrollToPlaceholder();
+    }
+    previousDrawerOpenRef.current = drawerOpen;
+  }, [drawerOpen, scrollToPlaceholder]);
 
   useEffect(() => {
     const shouldOpenDrawer = !hasDeposit && matchesDrawerSearch(
@@ -89,7 +181,9 @@ export default function LiveSearchSection({
     if (!closedByHistory) {
       setDrawerOpen(false);
     }
-  }, [location, navigate]);
+
+    scrollToPlaceholder();
+  }, [location, navigate, scrollToPlaceholder]);
 
   useEffect(() => {
     if (!hasDeposit) {return;}
@@ -194,6 +288,12 @@ export default function LiveSearchSection({
     }
   }, [boxSlug, handleDepositError, hasDeposit]);
 
+  const placeholderSx = isFixed && liveSearchHeight > 0
+    ? { height: `${liveSearchHeight}px` }
+    : undefined;
+  const liveSearchClassName = `liveSearch${isFixed ? " fixed" : ""}`;
+  const liveSearchStyle = isFixed ? { top: `${headerOffset}px` } : undefined;
+
   if (hasDeposit) {
     return (
       <MyDeposit
@@ -207,61 +307,67 @@ export default function LiveSearchSection({
   }
 
   return (
-    <Box className="liveSearch">
-      <Typography component="h3" variant="h4">
-        Ajoute une chanson à la boîte et gagne pleins de points
-      </Typography>
-
-      {errorMessage ? (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {errorMessage}
-        </Alert>
-      ) : null}
-
-      <Button variant="contained" onClick={openDrawer}>
-        Partager une chanson
-      </Button>
-
-      <Drawer
-        anchor="right"
-        open={drawerOpen}
-        onClose={() => closeDrawer()}
-        PaperProps={{
-          sx: {
-            width: "100vw",
-            maxWidth: "100vw",
-            height: "100vh",
-            overflow: "hidden",
-          },
-        }}
+    <Box ref={placeholderRef} sx={placeholderSx}>
+      <Box
+        ref={liveSearchRef}
+        className={liveSearchClassName}
+        style={liveSearchStyle}
       >
-        <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
-          <Box sx={{ p: 5, pb: 2 }}>
-            <Typography component="h2" variant="h3" sx={{ mb: 3 }}>
-              Choisis une chanson à partager
-            </Typography>
+        <Typography component="h3" variant="h4">
+          Ajoute une chanson à la boîte et gagne pleins de points
+        </Typography>
+
+        {errorMessage ? (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {errorMessage}
+          </Alert>
+        ) : null}
+
+        <Button variant="contained" onClick={openDrawer}>
+          Partager une chanson
+        </Button>
+
+        <Drawer
+          anchor="right"
+          open={drawerOpen}
+          onClose={() => closeDrawer()}
+          PaperProps={{
+            sx: {
+              width: "100vw",
+              maxWidth: "100vw",
+              height: "100vh",
+              overflow: "hidden",
+            },
+          }}
+        >
+          <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
+            <Box sx={{ p: 5, pb: 2 }}>
+              <Typography component="h2" variant="h3" sx={{ mb: 3 }}>
+                Choisis une chanson à partager
+              </Typography>
+            </Box>
+
+            {errorMessage ? (
+              <Alert severity="error" sx={{ mx: 5, mb: 2 }}>
+                {errorMessage}
+              </Alert>
+            ) : null}
+
+            {drawerOpen ? (
+              <SearchPanel
+                inputRef={searchInputRef}
+                onSelectSong={handleSongSelected}
+                actionLabel="Partager"
+                depositFlowState={depositFlowState}
+                onDepositVisualComplete={handleDepositVisualComplete}
+                rootSx={{ flex: 1, minHeight: 0 }}
+                searchBarWrapperSx={{ px: 5, pb: 2 }}
+                contentSx={{ overflowX: "hidden", overflowY: "scroll", flex: 1, pb: "96px" }}
+              />
+            ) : null}
           </Box>
-
-          {errorMessage ? (
-            <Alert severity="error" sx={{ mx: 5, mb: 2 }}>
-              {errorMessage}
-            </Alert>
-          ) : null}
-
-          {drawerOpen ? (
-            <SearchPanel
-              inputRef={searchInputRef}
-              onSelectSong={handleSongSelected}
-              actionLabel="Partager"
-              depositFlowState={depositFlowState}
-              onDepositVisualComplete={handleDepositVisualComplete}
-              rootSx={{ flex: 1, minHeight: 0 }}
-              searchBarWrapperSx={{ px: 5, pb: 2 }}
-              contentSx={{ overflowX: "hidden", overflowY: "scroll", flex: 1, pb: "96px" }}
-            />
-          ) : null}
-        </Box>
-      </Drawer>
+        </Drawer>
+      </Box>
     </Box>
   );
 }

--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.js
@@ -307,7 +307,7 @@ export default function LiveSearchSection({
   }
 
   return (
-    <Box ref={placeholderRef} sx={placeholderSx}>
+    <Box ref={placeholderRef} sx={placeholderSx} className"liveSearchPlaceholder">
       <Box
         ref={liveSearchRef}
         className={liveSearchClassName}

--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.js
@@ -307,7 +307,7 @@ export default function LiveSearchSection({
   }
 
   return (
-    <Box ref={placeholderRef} sx={placeholderSx} className"liveSearchPlaceholder">
+    <Box ref={placeholderRef} sx={placeholderSx} className="liveSearchPlaceholder">
       <Box
         ref={liveSearchRef}
         className={liveSearchClassName}

--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.test.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 
@@ -102,12 +102,13 @@ describe('LiveSearchSection', () => {
     jest.clearAllMocks();
     mockLatestSearchPanelProps = null;
     global.fetch = jest.fn();
+    HTMLElement.prototype.scrollIntoView = jest.fn();
   });
 
   test('shows a share CTA before deposit and opens the SearchPanel drawer through the URL', async () => {
     renderLiveSearchSection();
 
-    expect(screen.getByRole('heading', { name: /Partage une chanson/i, level: 3 })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Ajoute une chanson/i, level: 3 })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
 
     expect(await screen.findByText('Choisis une chanson à partager')).toBeInTheDocument();
@@ -126,6 +127,78 @@ describe('LiveSearchSection', () => {
       expect(screen.queryByText('Choisis une chanson à partager')).not.toBeInTheDocument();
     });
     expect(screen.getByTestId('location-search')).toBeEmptyDOMElement();
+  });
+
+
+  test('fixes LiveSearch below the measured header only before deposit API success', async () => {
+    global.fetch.mockResolvedValueOnce(mockJsonResponse({
+      my_deposit: { public_key: 'dep-1', song: { title: 'Search song', artist: 'Artist' } },
+      successes: [],
+      points_balance: 120,
+      deposit_points_earned: 0,
+    }));
+
+    const header = document.createElement('header');
+    document.body.appendChild(header);
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+    HTMLElement.prototype.getBoundingClientRect = function getBoundingClientRect() {
+      if (this === header) {
+        return { top: 0, height: 72, bottom: 72, left: 0, right: 0, width: 320, x: 0, y: 0, toJSON: () => {} };
+      }
+      if (this.classList?.contains('liveSearch')) {
+        return { top: 72, height: 144, bottom: 216, left: 0, right: 0, width: 320, x: 0, y: 72, toJSON: () => {} };
+      }
+      if (this.querySelector?.('.liveSearch')) {
+        return { top: 64, height: 144, bottom: 208, left: 0, right: 0, width: 320, x: 0, y: 64, toJSON: () => {} };
+      }
+      return originalGetBoundingClientRect.call(this);
+    };
+
+    try {
+      const { container } = renderLiveSearchSection();
+      const liveSearch = container.querySelector('.liveSearch');
+      expect(liveSearch).not.toHaveClass('fixed');
+
+      await act(async () => {
+        fireEvent.scroll(window);
+      });
+
+      await waitFor(() => {
+        expect(liveSearch).toHaveClass('fixed');
+      });
+      expect(liveSearch).toHaveStyle({ top: '72px' });
+      expect(liveSearch.parentElement).toHaveStyle({ height: '144px' });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
+      fireEvent.click(await screen.findByRole('button', { name: 'Choisir Search song' }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('deposit-flow-status')).toHaveTextContent('success');
+      });
+      await waitFor(() => {
+        expect(liveSearch).not.toHaveClass('fixed');
+      });
+      expect(liveSearch.parentElement).not.toHaveStyle({ height: '144px' });
+    } finally {
+      HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+      header.remove();
+    }
+  });
+
+  test('scrolls the LiveSearch placeholder into view when the search drawer closes', async () => {
+    renderLiveSearchSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
+    expect(await screen.findByText('Choisis une chanson à partager')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Retour navigateur'));
+
+    await waitFor(() => {
+      expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalledWith({
+        behavior: 'smooth',
+        block: 'center',
+      });
+    });
   });
 
   test('posts selected song, waits for the visual completion, updates user points and closes drawer', async () => {


### PR DESCRIPTION
### Motivation
- Keep the LiveSearch section visible during scroll while the user is still in pre-deposit mode so the deposit CTA remains accessible under a variable-height header. 
- Implement the sticky/fixed behavior in JS only (no final CSS changes) and avoid introducing legacy compatibility layers or component splits. 

### Description
- Encapsulate LiveSearch in a placeholder (`placeholderRef`) and the live element (`liveSearchRef`), adding state `isFixed` and only appending the class `fixed` when sticky is active. 
- Measure the app header dynamically using the selector `.MuiAppBar-root, header` via `getBoundingClientRect()` and apply that height as an inline `top` style for the fixed LiveSearch. 
- Measure LiveSearch height with a `ResizeObserver` (fallback to `getBoundingClientRect`) and reserve that height on the placeholder when `isFixed` is true to prevent page jump. 
- Drive fixed activation with scroll/resize listeners scheduled with `requestAnimationFrame`; the sticky logic activates only when `isPreDeposit === true` and is forced off after deposit API success or when `myDeposit` exists. 
- Keep the search drawer behavior: do not disable fixed when opening the drawer, and scroll the placeholder into view on drawer close via `placeholderRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })`. 
- Minimal DOM/CSS change: only the `fixed` class is added and the `top` inline style is injected; no final CSS styling was added. 

### Testing
- Ran unit tests with `npm test -- --watchAll=false LiveSearchSection.test.js` and the suite passed (10 tests). 
- Built the frontend with `npm run build` which completed successfully (webpack emitted size warnings only). 
- Files modified: `frontend/src/components/Flowbox/discover/LiveSearchSection.js` and `frontend/src/components/Flowbox/discover/LiveSearchSection.test.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fda483a0488332a2c0624356470b39)