### PR TITLE
Fix LiveSearch drawer close scroll

### DIFF
--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.js
@@ -146,7 +146,7 @@ export default function LiveSearchSection({
     setIsFixed((previousFixed) => (previousFixed ? false : previousFixed));
   }, [isPreDeposit]);
 
-  const scrollToPlaceholder = useCallback(() => {
+  const scrollToLiveSearch = useCallback(() => {
     placeholderRef.current?.scrollIntoView({
       behavior: "smooth",
       block: "center",
@@ -155,10 +155,10 @@ export default function LiveSearchSection({
 
   useEffect(() => {
     if (previousDrawerOpenRef.current && !drawerOpen) {
-      scrollToPlaceholder();
+      scrollToLiveSearch();
     }
     previousDrawerOpenRef.current = drawerOpen;
-  }, [drawerOpen, scrollToPlaceholder]);
+  }, [drawerOpen, scrollToLiveSearch]);
 
   useEffect(() => {
     const shouldOpenDrawer = !hasDeposit && matchesDrawerSearch(
@@ -181,9 +181,7 @@ export default function LiveSearchSection({
     if (!closedByHistory) {
       setDrawerOpen(false);
     }
-
-    scrollToPlaceholder();
-  }, [location, navigate, scrollToPlaceholder]);
+  }, [location, navigate]);
 
   useEffect(() => {
     if (!hasDeposit) {return;}

--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.test.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.test.js
@@ -108,7 +108,7 @@ describe('LiveSearchSection', () => {
   test('shows a share CTA before deposit and opens the SearchPanel drawer through the URL', async () => {
     renderLiveSearchSection();
 
-    expect(screen.getByRole('heading', { name: /Ajoute une chanson/i, level: 3 })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Ajoute une chanson/i, level: 5 })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
 
     expect(await screen.findByText('Choisis une chanson à partager')).toBeInTheDocument();
@@ -190,14 +190,16 @@ describe('LiveSearchSection', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
     expect(await screen.findByText('Choisis une chanson à partager')).toBeInTheDocument();
+    expect(HTMLElement.prototype.scrollIntoView).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByText('Retour navigateur'));
 
     await waitFor(() => {
-      expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalledWith({
-        behavior: 'smooth',
-        block: 'center',
-      });
+      expect(screen.queryByText('Choisis une chanson à partager')).not.toBeInTheDocument();
+    });
+    expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'center',
     });
   });
 
@@ -256,6 +258,10 @@ describe('LiveSearchSection', () => {
     expect(setUser.mock.calls[0][0]({ id: 1, points: 120 })).toEqual({ id: 1, points: 5060 });
     await waitFor(() => {
       expect(screen.queryByText('Choisis une chanson à partager')).not.toBeInTheDocument();
+    });
+    expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'center',
     });
   });
 


### PR DESCRIPTION
### Motivation
- Garantir que la page scrolle vers la section LiveSearch uniquement après la fermeture effective du drawer (incluant fermeture par bouton/back/escape et fermeture après dépôt réussi) pour éviter un scroll trop tôt ou double scroll.

### Description
- Ajout/renommage de la fonction `scrollToLiveSearch` (remplace l’ancien `scrollToPlaceholder`) qui cible le `placeholderRef` et appelle `scrollIntoView({ behavior: "smooth", block: "center" })`.
- Déclenchement du scroll centralisé dans un `useEffect` qui détecte précisément la transition `drawerOpen: true -> false` via `previousDrawerOpenRef`, couvrant la fermeture par historique navigateur.
- Suppression du `scrollIntoView` immédiat dans `closeDrawer()` pour éviter un scroll prématuré ou doublon lorsque la fermeture est effectuée via `closeDrawerWithHistory`/`navigate(-1)`.
- Mise à jour des tests dans `LiveSearchSection.test.js` pour vérifier que le scroll n’a pas lieu à l’ouverture, puis qu’il est appelé après la fermeture effective (browser back et après dépôt + animation), et ajustement d’une assertion de heading pour correspondre au `h5` rendu.
- Fichiers modifiés : `frontend/src/components/Flowbox/discover/LiveSearchSection.js`, `frontend/src/components/Flowbox/discover/LiveSearchSection.test.js`.

### Testing
- Commande exécutée : `cd frontend && npm test -- LiveSearchSection.test.js --watchAll=false`, résultat : tests ciblés réussis avec `10 passed, 0 failed`.
- Tests automatisés couverts : ouverture du drawer via URL, fermeture par retour navigateur déclenchant le scroll, fermeture après dépôt réussi déclenchant le scroll, et autres cas existants (network error, conflict, fixed positioning).
- Le test lancé depuis la racine du dépôt échoue si exécuté sans `package.json` à la racine, donc les tests ciblés ont été exécutés depuis `frontend` et ont passé avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdbc09972c8332aec5b350a0a2a3d7)