### PR TITLE
Harmonize Flowbox user-facing wording (French)

### DIFF
--- a/box_management/services/deposits/achievements.py
+++ b/box_management/services/deposits/achievements.py
@@ -77,8 +77,8 @@ def build_successes(
         bonus = nb_consecutive_days * int(NB_POINTS_CONSECUTIVE_DAYS_BOX)
         points_to_add += bonus
         successes["consecutive_days"] = {
-            "name": "Amour fou",
-            "desc": f"{nb_consecutive_days + 1} jours consécutifs avec cette boite",
+            "name": "Série en cours",
+            "desc": "Tu es revenu déposer plusieurs jours de suite.",
             "points": bonus,
             "emoji": "🔥",
         }
@@ -86,8 +86,8 @@ def build_successes(
     if user and not has_user_deposit_in_box:
         points_to_add += int(NB_POINTS_FIRST_DEPOSIT_USER_ON_BOX)
         successes["first_user_deposit_box"] = {
-            "name": "Explorateur·ice",
-            "desc": "C’est ta première chanson dans cette boîte",
+            "name": "Première fois ici",
+            "desc": "C’est ton premier dépôt dans cette boîte.",
             "points": int(NB_POINTS_FIRST_DEPOSIT_USER_ON_BOX),
             "emoji": "🔍",
         }
@@ -99,8 +99,8 @@ def build_successes(
     if is_first_song_in_box:
         points_to_add += int(NB_POINTS_FIRST_SONG_DEPOSIT_BOX)
         successes["first_song_deposit"] = {
-            "name": "Far West",
-            "desc": "Cette chanson n’a jamais été déposée dans cette boîte",
+            "name": "Nouvelle dans cette boîte",
+            "desc": "Cette chanson n’avait jamais été déposée dans cette boîte.",
             "points": int(NB_POINTS_FIRST_SONG_DEPOSIT_BOX),
             "emoji": "🤠",
         }
@@ -112,15 +112,15 @@ def build_successes(
     if is_first_song_global:
         points_to_add += int(NB_POINTS_FIRST_SONG_DEPOSIT_GLOBAL)
         successes["first_song_deposit_global"] = {
-            "name": "Preums",
-            "desc": "Cette chanson n'a jamais été déposée sur le réseau",
+            "name": "Nouvelle sur le réseau",
+            "desc": "Cette chanson n’avait jamais été déposée sur le réseau.",
             "points": int(NB_POINTS_FIRST_SONG_DEPOSIT_GLOBAL),
             "emoji": "🥇",
         }
 
     successes["default_deposit"] = {
-        "name": "Pépite",
-        "desc": "Tu as partagé·e une chanson",
+        "name": "Dépôt validé",
+        "desc": "Tu as déposé une chanson.",
         "points": int(NB_POINTS_ADD_SONG),
         "emoji": "💎",
     }

--- a/docs/flowbox-wording-lexicon.md
+++ b/docs/flowbox-wording-lexicon.md
@@ -1,0 +1,118 @@
+# Lexique Flowbox
+
+Ce document définit le wording utilisateur du flow Flowbox.
+
+## Objectif
+
+Le flow Flowbox doit être compris rapidement par un nouvel utilisateur.
+
+La règle à faire comprendre est :
+
+1. L’utilisateur ouvre une boîte sur place.
+2. Il écoute ce que les autres ont laissé.
+3. Il dépose une chanson.
+4. Il gagne des points.
+5. Il utilise ses points pour révéler d’autres chansons.
+6. Il peut répondre, réagir ou mettre une chanson en avant.
+7. La boîte se referme à la fin du temps disponible.
+
+## Phrase de référence
+
+Ouvre une boîte sur place.
+Écoute ce que les autres ont laissé.
+Dépose ta chanson pour gagner des points.
+Utilise tes points pour révéler d’autres morceaux.
+
+## Lexique obligatoire
+
+| Concept | Terme à utiliser |
+|---|---|
+| Entrée dans une boîte | ouvrir la boîte |
+| Session temporaire | explorer la boîte |
+| Vérification de proximité | vérifier que tu es près de la boîte |
+| Action principale | déposer une chanson |
+| Récompense | gagner des points |
+| Chanson cachée | révéler une chanson |
+| Commentaires | répondre à une chanson |
+| Ancienne chanson épinglée | chanson mise en avant |
+| Action d’épinglage | mettre une chanson en avant |
+| Fin de session | la boîte est refermée |
+
+## Termes à éviter
+
+| Terme à éviter | Remplacement |
+|---|---|
+| partager une chanson | déposer une chanson |
+| ajouter une chanson | déposer une chanson |
+| débloquer une chanson | révéler une chanson |
+| chanson épinglée | chanson mise en avant |
+| épingler | mettre en avant |
+| mission | session / exploration |
+| pour éviter la triche | vérifier que tu es sur place |
+| hors zone | pas assez près de la boîte |
+
+## Ton
+
+Le ton doit être :
+- clair ;
+- direct ;
+- pédagogique ;
+- rassurant ;
+- accessible à quelqu’un qui découvre le service.
+
+Le ton ne doit pas être :
+- trop gaming ;
+- trop technique ;
+- accusateur ;
+- abstrait ;
+- marketing.
+
+## Exemples recommandés
+
+### Entrée
+
+Découvre les chansons laissées ici.
+
+Cette boîte contient les morceaux déposés par les personnes passées avant toi. Ouvre-la pour écouter, déposer ta chanson et révéler la suite.
+
+### Localisation
+
+Vérifie que tu es près de la boîte.
+
+Cette boîte est liée à un lieu précis. On utilise ta position uniquement pour vérifier que tu es sur place.
+
+### Dépôt
+
+Dépose ta chanson dans la boîte.
+
+Tu gagnes des points. Ils servent à révéler les chansons cachées.
+
+### Révélation
+
+Maintiens pour révéler.
+
+Dépose une chanson pour gagner des points et révéler ce morceau.
+
+### Mise en avant
+
+Chanson mise en avant.
+
+Une chanson mise en avant reste visible pour toutes les personnes qui ouvrent cette boîte pendant un temps limité.
+
+### Fin de session
+
+La boîte est refermée.
+
+Ton temps d’exploration est terminé. Pour rouvrir cette boîte, scanne à nouveau son QR code sur place.
+
+## Règle importante pour le code
+
+Les noms techniques existants ne doivent pas forcément être renommés.
+
+Exemples :
+- pinnedSong peut rester pinnedSong ;
+- deposit_type="pinned" peut rester inchangé ;
+- les endpoints existants peuvent rester inchangés ;
+- les classes CSS peuvent rester inchangées.
+
+Cette documentation concerne principalement les textes visibles par l’utilisateur.

--- a/frontend/src/components/Common/Deposit/Deposit.js
+++ b/frontend/src/components/Common/Deposit/Deposit.js
@@ -369,7 +369,7 @@ export default function Deposit({
 
       if (!res.ok) {
         if (payload?.code === "INSUFFICIENT_POINTS") {
-          openActionErrorDialog("Pas assez de points", payload?.detail || "Tu n’as pas assez de points pour effectuer cette action.");
+          openActionErrorDialog("Pas assez de points", payload?.detail || "Dépose une chanson pour gagner des points et révéler ce morceau.");
         } else if (payload?.detail) {
           openActionErrorDialog("Impossible de révéler la chanson", payload.detail);
         } else {
@@ -463,7 +463,7 @@ export default function Deposit({
   const toggleCommentsInline = useCallback((event) => {
     event?.stopPropagation?.();
     if (!isRevealed) {
-      openActionErrorDialog("Réponses indisponibles", "Révèle la chanson pour voir les réponses", event);
+      openActionErrorDialog("Révèle d’abord cette chanson", "Tu pourras réagir une fois le morceau révélé.", event);
       return;
     }
     setCommentsOpen((prev) => !prev);
@@ -512,7 +512,7 @@ export default function Deposit({
         blurActiveElement();
         setCommentsOpen(true);
       } else {
-        openActionErrorDialog("Réponses indisponibles", "Révèle la chanson pour voir les réponses");
+        openActionErrorDialog("Révèle d’abord cette chanson", "Tu pourras réagir une fois le morceau révélé.");
       }
       return;
     }
@@ -891,9 +891,9 @@ export default function Deposit({
         open={reactionRevealPromptOpen}
         onClose={() => setReactionRevealPromptOpen(false)}
       >
-        <DialogTitle>Réaction indisponible</DialogTitle>
+        <DialogTitle>Révèle d’abord cette chanson</DialogTitle>
         <DialogContent>
-          <Typography variant="body1">Écoute la chanson avant de réagir.</Typography>
+          <Typography variant="body1">Tu pourras réagir une fois le morceau révélé.</Typography>
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setReactionRevealPromptOpen(false)}>Compris</Button>

--- a/frontend/src/components/Common/Deposit/comments/DepositComments.js
+++ b/frontend/src/components/Common/Deposit/comments/DepositComments.js
@@ -123,9 +123,10 @@ export default function DepositComments({
             songRequired={false}
             drawerAnchor="right"
             searchDrawerTitle="Attacher une chanson"
+            attachSongLabel="Attacher une chanson"
             songActionLabel="Choisir"
-            textLabel="Répondre"
-            textPlaceholder="Répondre"
+            textLabel="Répondre à cette chanson"
+            textPlaceholder="Répondre à cette chanson"
             onBlockedInteraction={() => setIsConsecutiveReplyDialogOpen(true)}
             onSubmit={async (payload) => {
               setSubmitting(true);
@@ -168,9 +169,9 @@ export default function DepositComments({
       </Box>
 
       <Dialog open={isConsecutiveReplyDialogOpen} onClose={closeConsecutiveReplyDialog}>
-        <DialogTitle>Réponse indisponible</DialogTitle>
+        <DialogTitle>Tu as déjà répondu</DialogTitle>
         <DialogContent>
-          <Typography>Tu ne peux pas envoyer deux réponses d’affilé</Typography>
+          <Typography>Attends que quelqu’un réponde avant d’écrire à nouveau.</Typography>
         </DialogContent>
         <DialogActions>
           <Button onClick={closeConsecutiveReplyDialog} variant="contained">J’ai compris</Button>

--- a/frontend/src/components/Common/Deposit/parts/DepositSong.js
+++ b/frontend/src/components/Common/Deposit/parts/DepositSong.js
@@ -302,7 +302,7 @@ export default function DepositSong({
             sx={{ touchAction: "none" }}
             startIcon={isRevealLoading ? <CircularProgress size={18} thickness={5} color="inherit" /> : null}
           >
-            {isRevealLoading ? "Révélation..." : "Maintiens pour révéler la chanson"}
+            {isRevealLoading ? "Révélation en cours..." : "Maintiens pour révéler"}
             <Box className="points_container" sx={{ ml: "12px" }}>
               <Typography variant="body1" component="span" sx={{ color: "text.primary" }}>
                 {revealCost}

--- a/frontend/src/components/Common/Deposit/reactions/DepositReactions.js
+++ b/frontend/src/components/Common/Deposit/reactions/DepositReactions.js
@@ -18,7 +18,7 @@ import AuthModal from "../../../Auth/AuthModal";
 import { getCookie } from "../../../Security/TokensUtils";
 import { UserContext } from "../../../UserContext";
 
-const EMOJI_POINTS_MESSAGE = "Tu n’as assez de points pour débloquer cet émoji. Les dépôts te font gagner des points.";
+const EMOJI_POINTS_MESSAGE = "Tu n’as pas assez de points pour révéler cet émoji. Les dépôts te font gagner des points.";
 
 export default function DepositReactions({
   open,
@@ -195,7 +195,7 @@ export default function DepositReactions({
 
         setInlineAlert({
           severity: "error",
-          message: data?.detail || "Impossible de débloquer cet emoji.",
+          message: data?.detail || "Impossible de révéler cet emoji.",
           retryAction: "retry_unlock",
         });
         return;
@@ -205,7 +205,7 @@ export default function DepositReactions({
     } catch (error) {
       setInlineAlert({
         severity: "error",
-        message: "Impossible de débloquer cet emoji.",
+        message: "Impossible de révéler cet emoji.",
         retryAction: "retry_unlock",
       });
     } finally {

--- a/frontend/src/components/Common/Menu.js
+++ b/frontend/src/components/Common/Menu.js
@@ -133,9 +133,9 @@ export default function MenuAppBar() {
   const helperText = useMemo(() => {
     if (!activeSession) {return "";}
     if (remainingMs <= ERROR_THRESHOLD_MS) {
-      return `Tu as accès à tout le contenu de la boîte pendant encore ${formatLongRemaining(remainingMs)}.`;
+      return "La boîte se referme bientôt. Termine ton dépôt ou révèle les chansons qui t’intéressent.";
     }
-    return `Tu as accès à tout le contenu de la boîte pendant ${formatLongRemaining(remainingMs)}.`;
+    return `Tu peux explorer cette boîte encore ${formatLongRemaining(remainingMs)}.`;
   }, [activeSession, remainingMs]);
 
   return (

--- a/frontend/src/components/Flowbox/AchievementsPanel.js
+++ b/frontend/src/components/Flowbox/AchievementsPanel.js
@@ -24,8 +24,8 @@ export default function AchievementsPanel({ successes = [] }) {
   return (
     <Box sx={{ display: "grid", gap: 0, p: "76px 0" }}>
       <Box className="intro_small">
-        <Typography variant="h1">Détail de tes points</Typography>
-        <Typography variant="body1">Tu gagnes des points selon la chanson que tu déposes</Typography>
+        <Typography variant="h1">Points gagnés avec ton dépôt</Typography>
+        <Typography variant="body1">Chaque dépôt rapporte des points. Des bonus s’ajoutent quand ta chanson est nouvelle dans cette boîte ou sur le réseau.</Typography>
 
         <Box
           className="points_container points_container_big"

--- a/frontend/src/components/Flowbox/ClosedBoxPage.js
+++ b/frontend/src/components/Flowbox/ClosedBoxPage.js
@@ -21,10 +21,10 @@ export default function ClosedBoxPage() {
         <Box sx={{ display: "grid", gap: 1, justifyItems: "center" }}>
           <LockIcon fontSize="large" />
           <Typography component="h1" variant="h3">
-            Ton temps dans la boîte est terminé
+            La boîte est refermée
           </Typography>
           <Typography component="p" variant="body1">
-            {`La boîte ${boxName} s’est refermée. Pour y entrer à nouveau, scanne une boîte près de toi.`}
+            Ton temps d’exploration est terminé. Pour rouvrir cette boîte, scanne à nouveau son QR code sur place.
           </Typography>
         </Box>
 
@@ -33,7 +33,7 @@ export default function ClosedBoxPage() {
         </Button>
 
         <Button variant="light" component={Link} to="/profile" startIcon={<PersonIcon />}>
-          Aller sur mon profil
+          Voir mon profil
         </Button>
       </Box>
     </Box>

--- a/frontend/src/components/Flowbox/Discover.js
+++ b/frontend/src/components/Flowbox/Discover.js
@@ -250,7 +250,7 @@ export default function Discover() {
 
       <Box className="intro">
         <Typography component="h2" variant="h1">
-          Découvre les chansons déposées par les personnes précédentes
+          Les chansons de cette boîte
         </Typography>
       </Box>
 
@@ -262,7 +262,7 @@ export default function Discover() {
         <Box sx={{ p: 3 }}>
           <Alert severity="info">
             Aucune chanson à découvrir pour le moment. Reviens bientôt : les prochains
-            partages apparaîtront ici.
+            dépôts apparaîtront ici.
           </Alert>
         </Box>
       )}

--- a/frontend/src/components/Flowbox/Discover.test.js
+++ b/frontend/src/components/Flowbox/Discover.test.js
@@ -18,10 +18,13 @@ jest.mock('../Common/Deposit', () => ({
 
 jest.mock('../Common/Search/SearchPanel', () => ({
   __esModule: true,
-  default: ({ onSelectSong }) => (
+  default: ({ onSelectSong, onDepositVisualComplete }) => (
     <button
       type="button"
-      onClick={() => onSelectSong({ id: 'track-1', name: 'Posted song', artist: 'Artist', image_url: 'cover.jpg' }, 'request-1')}
+      onClick={async () => {
+        await onSelectSong({ id: 'track-1', name: 'Posted song', artist: 'Artist', image_url: 'cover.jpg' }, 'request-1');
+        onDepositVisualComplete?.('request-1');
+      }}
     >
       Choisir Posted song
     </button>
@@ -150,6 +153,7 @@ describe('Discover', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     intersectionObservers = [];
+    HTMLElement.prototype.scrollIntoView = jest.fn();
     delete window.IntersectionObserver;
   });
 
@@ -244,8 +248,8 @@ describe('Discover', () => {
 
     const mainDeposit = await screen.findByTestId('deposit-main');
     const liveSearchHeading = screen.getByRole('heading', {
-      name: /Partage une chanson pour gagner des points/i,
-      level: 3,
+      name: /Dépose ta chanson dans la boîte/i,
+      level: 5,
     });
     const article = await screen.findByTestId('article-card');
 
@@ -269,8 +273,8 @@ describe('Discover', () => {
 
     const emptyState = await screen.findByText(/Aucune chanson à découvrir/i);
     const liveSearchHeading = screen.getByRole('heading', {
-      name: /Partage une chanson pour gagner des points/i,
-      level: 3,
+      name: /Dépose ta chanson dans la boîte/i,
+      level: 5,
     });
     const article = await screen.findByTestId('article-card');
 
@@ -304,15 +308,25 @@ describe('Discover', () => {
 
     expect(await screen.findByTestId('deposit-main')).toHaveTextContent('main-1');
     expect(await screen.findByText('older-1')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Choisir Posted song' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Déposer une chanson' }));
+    await act(async () => {
+      fireEvent.click(await screen.findByRole('button', { name: 'Choisir Posted song' }));
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/box-management/box-deposit/'),
+      expect.any(Object),
+    ));
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+    });
 
-    expect(await screen.findByText('Chanson déposée avec succès')).toBeInTheDocument();
+    expect(await screen.findByText('Ta chanson est dans la boîte')).toBeInTheDocument();
     expect(screen.getByText('Posted song')).toBeInTheDocument();
     expect(screen.getByTestId('deposit-main')).toHaveTextContent('main-1');
     expect(screen.getByText('older-1')).toBeInTheDocument();
     expect(screen.queryByText(/Aucune chanson à découvrir/i)).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Partager une chanson' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Déposer une chanson' })).not.toBeInTheDocument();
 
     expect(patchDiscoverSnapshot).toHaveBeenCalledWith(
       'box-a',
@@ -522,12 +536,12 @@ describe('Discover', () => {
     const myDepositSection = screen.getByTestId('my-deposit');
     const article = await screen.findByTestId('article-card');
 
-    expect(within(myDepositSection).getByText('Chanson déposée avec succès')).toBeInTheDocument();
+    expect(within(myDepositSection).getByText('Ta chanson est dans la boîte')).toBeInTheDocument();
     expect(within(myDepositSection).getByText('Déjà déposée')).toBeInTheDocument();
     expect(within(myDepositSection).getByText('+48')).toBeInTheDocument();
     expectNodeBefore(mainDeposit, myDepositSection);
     expectNodeBefore(myDepositSection, article);
-    expect(screen.queryByRole('button', { name: 'Partager une chanson' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Déposer une chanson' })).not.toBeInTheDocument();
   });
 
   test('redirects to closed when box-content requires a session', async () => {

--- a/frontend/src/components/Flowbox/EnableLocation.js
+++ b/frontend/src/components/Flowbox/EnableLocation.js
@@ -36,11 +36,11 @@ export default function EnableLocation({
       >
         <Box sx={{ display: "grid", gap: "16px", textAlign: "center" }}>
           <Typography variant="h3" component="h1">
-            Ouvre la boîte grâce à ta localisation
+            Vérifie que tu es près de la boîte
           </Typography>
 
           <Typography variant="body1">
-            Pour éviter la triche, la boîte s’ouvre seulement si tu es sur place.
+            Cette boîte est liée à un lieu précis. On utilise ta position uniquement pour vérifier que tu es sur place.
           </Typography>
 
           <Button
@@ -57,7 +57,7 @@ export default function EnableLocation({
                 Vérification...
               </Box>
             ) : (
-              "Autoriser"
+              "Autoriser la localisation"
             )}
           </Button>
         </Box>

--- a/frontend/src/components/Flowbox/Onboarding.js
+++ b/frontend/src/components/Flowbox/Onboarding.js
@@ -40,7 +40,7 @@ function getDeviceOs() {
 }
 
 function getPermissionDialogContent(os) {
-  const title = "Autorise la localisation pour continuer";
+  const title = "Localisation refusée";
   if (os === "ios") {
     return {
       title,
@@ -242,7 +242,7 @@ export default function Onboarding() {
 
           <Box className="container">
             <Typography variant="h3" component="h1" className="intro_small">
-              Découvre les chansons déposées ici par d'autres passants
+              Découvre les chansons laissées ici
             </Typography>
 
             {pageError ? (
@@ -286,10 +286,10 @@ export default function Onboarding() {
         fullWidth
         maxWidth="xs"
       >
-        <DialogTitle>Tu es trop loin</DialogTitle>
+        <DialogTitle>Tu n’es pas assez près de la boîte</DialogTitle>
         <DialogContent>
           <Typography variant="body1">
-            Rapproche-toi de la boîte pour l’ouvrir.
+            Rapproche-toi du lieu où se trouve la boîte, puis réessaie.
           </Typography>
         </DialogContent>
         <DialogActions>

--- a/frontend/src/components/Flowbox/PinnedSongSection.js
+++ b/frontend/src/components/Flowbox/PinnedSongSection.js
@@ -57,19 +57,19 @@ function formatRemainingTime(remainingMs) {
 }
 
 function buildPinnedDateLabel(dep) {
-  if (!dep?.deposited_at) {return "Épinglée";}
+  if (!dep?.deposited_at) {return "Mise en avant";}
   const depositedAt = new Date(dep.deposited_at).getTime();
-  if (!depositedAt) {return "Épinglée";}
+  if (!depositedAt) {return "Mise en avant";}
 
   const diffMs = Math.max(0, Date.now() - depositedAt);
   const totalMinutes = Math.floor(diffMs / 60000);
   const totalHours = Math.floor(totalMinutes / 60);
   const days = Math.floor(totalHours / 24);
 
-  if (days > 0) {return `Épinglée il y a ${days} j`;}
-  if (totalHours > 0) {return `Épinglée il y a ${totalHours} h`;}
-  if (totalMinutes > 0) {return `Épinglée il y a ${totalMinutes} min`;}
-  return "Épinglée à l’instant";
+  if (days > 0) {return `Mise en avant il y a ${days} j`;}
+  if (totalHours > 0) {return `Mise en avant il y a ${totalHours} h`;}
+  if (totalMinutes > 0) {return `Mise en avant il y a ${totalMinutes} min`;}
+  return "Mise en avant à l’instant";
 }
 
 const PINNED_SONG_DRAWER_PARAM = "flowboxDrawer";
@@ -117,7 +117,7 @@ export default function PinnedSongSection({ boxSlug, initialPinnedDeposit }) {
 
       const data = await response.json().catch(() => ({}));
       if (!response.ok) {
-        throw new Error(data?.detail || "Impossible de charger la chanson épinglée.");
+        throw new Error(data?.detail || "Impossible de charger la chanson mise en avant.");
       }
 
       const nextActivePinnedDeposit = data?.active_pinned_deposit || null;
@@ -278,7 +278,7 @@ export default function PinnedSongSection({ boxSlug, initialPinnedDeposit }) {
         }
         setErrorDialog({
           open: true,
-          message: data?.detail || "Impossible d’épingler cette chanson.",
+          message: data?.detail || "Impossible de mettre cette chanson en avant.",
         });
         return;
       }
@@ -293,7 +293,7 @@ export default function PinnedSongSection({ boxSlug, initialPinnedDeposit }) {
     } catch {
       setErrorDialog({
         open: true,
-        message: "Impossible d’épingler cette chanson.",
+        message: "Impossible de mettre cette chanson en avant.",
       });
     } finally {
       setPosting(false);
@@ -353,7 +353,7 @@ export default function PinnedSongSection({ boxSlug, initialPinnedDeposit }) {
       return (
         <>
           <Typography variant="body1" sx={{ textAlign: "center", mb: 2 }}>
-            Crée ton compte pour pouvoir épingler une chanson.
+            Crée ton compte pour pouvoir mettre une chanson en avant.
           </Typography>
           <Button
             variant="contained"
@@ -378,10 +378,10 @@ export default function PinnedSongSection({ boxSlug, initialPinnedDeposit }) {
     return (
       <>
         <Typography variant="body1" sx={{ textAlign: "center", mb: 2 }}>
-          Aucune chanson épinglée pour le moment
+          Aucune chanson mise en avant pour le moment.
         </Typography>
         <Button variant="light" onClick={openSearchDrawer}>
-          Épingler une chanson
+          Mettre une chanson en avant
         </Button>
       </>
     );
@@ -401,9 +401,9 @@ export default function PinnedSongSection({ boxSlug, initialPinnedDeposit }) {
             pb: 1,
           }}
         >
-          <Typography variant="h4">Épinglée ici</Typography>
+          <Typography variant="h4">Chanson mise en avant</Typography>
           <Typography component="p" variant="body1" sx={{ mb: 3 }}>
-            La chanson épinglée reste visible pour tous les passants ouvrant cette boîte pendant un temps donné.
+            Une chanson mise en avant reste visible pour toutes les personnes qui ouvrent cette boîte pendant un temps limité.
           </Typography>
         </Box>
 
@@ -441,7 +441,7 @@ export default function PinnedSongSection({ boxSlug, initialPinnedDeposit }) {
               <>
                 <Box sx={{ p: 5, pb: 2 }}>
                   <Typography component="h2" variant="h3" sx={{ mb: 3 }}>
-                    Choisis une chanson à épingler
+                    Choisis la chanson à mettre en avant
                   </Typography>
                 </Box>
 
@@ -481,7 +481,7 @@ export default function PinnedSongSection({ boxSlug, initialPinnedDeposit }) {
                     Choisis une durée
                   </Typography>
                   <Typography component="p" variant="body1" sx={{ mb: 3 }}>
-                    Choisis pendant combien de temps ta chanson sera épinglée à la boîte.
+                    Choisis combien de temps elle restera visible.
                   </Typography>
 
                   <Box className="my_deposit deposit_card deposit_song" sx={{ width: "100%", boxSizing: "border-box" }}>
@@ -571,7 +571,7 @@ export default function PinnedSongSection({ boxSlug, initialPinnedDeposit }) {
               {drawerStep === "duration"
                 ? posting
                   ? "Validation..."
-                  : `Épingler pour ${selectedPrice} points`
+                  : `Mettre en avant pour ${selectedPrice} points`
                 : "Fermer"}
             </Button>
           </Box>
@@ -582,7 +582,7 @@ export default function PinnedSongSection({ boxSlug, initialPinnedDeposit }) {
         open={errorDialog.open}
         onClose={() => setErrorDialog({ open: false, message: "" })}
       >
-        <DialogTitle>Impossible d’épingler la chanson</DialogTitle>
+        <DialogTitle>Impossible de mettre la chanson en avant</DialogTitle>
         <DialogContent>
           <Alert severity="error">{errorDialog.message}</Alert>
         </DialogContent>

--- a/frontend/src/components/Flowbox/PinnedSongSection.test.js
+++ b/frontend/src/components/Flowbox/PinnedSongSection.test.js
@@ -105,11 +105,11 @@ describe('PinnedSongSection', () => {
       expect.any(Object)
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: /épingler une chanson/i }));
-    expect(await screen.findByText('Choisis une chanson à épingler')).toBeInTheDocument();
+    fireEvent.click(await screen.findByRole('button', { name: /mettre une chanson en avant/i }));
+    expect(await screen.findByText('Choisis la chanson à mettre en avant')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Choisir ce morceau' }));
     expect(await screen.findByText('Choisis une durée')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Épingler pour 100 points/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Mettre en avant pour 100 points/i })).toBeInTheDocument();
   });
 
   test('shows error dialog when pin request fails', async () => {
@@ -118,7 +118,7 @@ describe('PinnedSongSection', () => {
       json: async () => ({ active_pinned_deposit: null, price_steps: [{ minutes: 15, points: 100, is_affordable: true }] }),
     }).mockResolvedValueOnce({
       ok: false,
-      json: async () => ({ detail: 'Impossible d’épingler cette chanson.' }),
+      json: async () => ({ detail: 'Impossible de mettre cette chanson en avant.' }),
     });
 
     await act(async () => {
@@ -126,12 +126,12 @@ describe('PinnedSongSection', () => {
     });
 
     await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
-    fireEvent.click(await screen.findByRole('button', { name: /épingler une chanson/i }));
-    await screen.findByText('Choisis une chanson à épingler');
+    fireEvent.click(await screen.findByRole('button', { name: /mettre une chanson en avant/i }));
+    await screen.findByText('Choisis la chanson à mettre en avant');
     fireEvent.click(screen.getByRole('button', { name: 'Choisir ce morceau' }));
     await screen.findByText('Choisis une durée');
-    fireEvent.click(screen.getByRole('button', { name: /Épingler pour 100 points/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Mettre en avant pour 100 points/i }));
 
-    expect(await screen.findByText('Impossible d’épingler cette chanson.')).toBeInTheDocument();
+    expect(await screen.findByText('Impossible de mettre cette chanson en avant.')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.js
@@ -20,8 +20,8 @@ import MyDeposit from "./MyDeposit";
 
 const LIVE_SEARCH_DRAWER_PARAM = "drawer";
 const LIVE_SEARCH_DRAWER_VALUE = "live-search";
-const DEFAULT_ERROR_MESSAGE = "Impossible de partager cette chanson pour le moment.";
-const ALREADY_EXISTS_MESSAGE = "Tu as déjà partagé une chanson dans cette session.";
+const DEFAULT_ERROR_MESSAGE = "Impossible de déposer cette chanson pour le moment.";
+const ALREADY_EXISTS_MESSAGE = "Tu as déjà déposé une chanson dans cette session.";
 const HEADER_SELECTOR = ".MuiAppBar-root, header";
 const POST_DEPOSIT_SCROLL_IDLE_MS = 160;
 const POST_DEPOSIT_NO_SCROLL_FALLBACK_MS = 1000;
@@ -400,7 +400,11 @@ export default function LiveSearchSection({
             style={liveSearchStyle}
           >
             <Typography component="h5" variant="h5">
-              Ajoute une chanson à la boîte pour gagner des points et révéler plus de chansons
+              Dépose ta chanson dans la boîte
+            </Typography>
+
+            <Typography variant="body1">
+              Tu gagnes des points. Ils servent à révéler les chansons cachées.
             </Typography>
 
             {errorMessage ? (
@@ -410,7 +414,7 @@ export default function LiveSearchSection({
             ) : null}
 
             <Button variant="contained" onClick={openDrawer}>
-              Partager une chanson
+              Déposer une chanson
             </Button>
 
             <Drawer
@@ -429,7 +433,7 @@ export default function LiveSearchSection({
               <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
                 <Box sx={{ p: 5, pb: 2 }}>
                   <Typography component="h2" variant="h3" sx={{ mb: 3 }}>
-                    Choisis une chanson à partager
+                    Choisis la chanson à déposer
                   </Typography>
                 </Box>
 
@@ -443,7 +447,8 @@ export default function LiveSearchSection({
                   <SearchPanel
                     inputRef={searchInputRef}
                     onSelectSong={handleSongSelected}
-                    actionLabel="Partager"
+                    actionLabel="Déposer"
+                    placeholder="Chercher une chanson ou un artiste"
                     depositFlowState={depositFlowState}
                     onDepositVisualComplete={handleDepositVisualComplete}
                     rootSx={{ flex: 1, minHeight: 0 }}

--- a/frontend/src/components/Flowbox/discover/LiveSearchSection.test.js
+++ b/frontend/src/components/Flowbox/discover/LiveSearchSection.test.js
@@ -146,23 +146,23 @@ describe('LiveSearchSection', () => {
   test('shows a share CTA before deposit and opens the SearchPanel drawer through the URL', async () => {
     renderLiveSearchSection();
 
-    expect(screen.getByRole('heading', { name: /Ajoute une chanson/i, level: 5 })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
+    expect(screen.getByRole('heading', { name: /Dépose ta chanson/i, level: 5 })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Déposer une chanson' }));
 
-    expect(await screen.findByText('Choisis une chanson à partager')).toBeInTheDocument();
+    expect(await screen.findByText('Choisis la chanson à déposer')).toBeInTheDocument();
     expect(screen.getByTestId('location-search')).toHaveTextContent('drawer=live-search');
   });
 
   test('browser back closes the URL-driven drawer', async () => {
     renderLiveSearchSection({});
 
-    fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
-    expect(await screen.findByText('Choisis une chanson à partager')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Déposer une chanson' }));
+    expect(await screen.findByText('Choisis la chanson à déposer')).toBeInTheDocument();
 
     fireEvent.click(screen.getByText('Retour navigateur'));
 
     await waitFor(() => {
-      expect(screen.queryByText('Choisis une chanson à partager')).not.toBeInTheDocument();
+      expect(screen.queryByText('Choisis la chanson à déposer')).not.toBeInTheDocument();
     });
     expect(screen.getByTestId('location-search')).toBeEmptyDOMElement();
   });
@@ -207,7 +207,7 @@ describe('LiveSearchSection', () => {
       expect(liveSearch).toHaveStyle({ top: '72px' });
       expect(liveSearch.parentElement).toHaveStyle({ height: '144px' });
 
-      fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Déposer une chanson' }));
       fireEvent.click(await screen.findByRole('button', { name: 'Choisir Search song' }));
 
       await waitFor(() => {
@@ -226,13 +226,13 @@ describe('LiveSearchSection', () => {
   test('does not scroll when the search drawer closes without a successful deposit', async () => {
     renderLiveSearchSection();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
-    expect(await screen.findByText('Choisis une chanson à partager')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Déposer une chanson' }));
+    expect(await screen.findByText('Choisis la chanson à déposer')).toBeInTheDocument();
 
     fireEvent.click(screen.getByText('Retour navigateur'));
 
     await waitFor(() => {
-      expect(screen.queryByText('Choisis une chanson à partager')).not.toBeInTheDocument();
+      expect(screen.queryByText('Choisis la chanson à déposer')).not.toBeInTheDocument();
     });
     expect(HTMLElement.prototype.scrollIntoView).not.toHaveBeenCalled();
   });
@@ -248,7 +248,7 @@ describe('LiveSearchSection', () => {
 
     const { onDepositCreated, setUser } = renderLiveSearchSection({}, { syncDepositState: true });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Déposer une chanson' }));
     expect(await screen.findByTestId('deposit-visual-callback')).toHaveTextContent('enabled');
 
     fireEvent.click(await screen.findByRole('button', { name: 'Choisir Search song' }));
@@ -275,7 +275,7 @@ describe('LiveSearchSection', () => {
     expect(mockLatestSearchPanelProps.onDepositVisualComplete).toEqual(expect.any(Function));
     expect(onDepositCreated).not.toHaveBeenCalled();
     expect(setUser).not.toHaveBeenCalled();
-    expect(screen.getByText('Choisis une chanson à partager')).toBeInTheDocument();
+    expect(screen.getByText('Choisis la chanson à déposer')).toBeInTheDocument();
 
     jest.useFakeTimers();
 
@@ -283,7 +283,7 @@ describe('LiveSearchSection', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Terminer animation' }));
 
       await waitFor(() => {
-        expect(screen.queryByText('Choisis une chanson à partager')).not.toBeInTheDocument();
+        expect(screen.queryByText('Choisis la chanson à déposer')).not.toBeInTheDocument();
       });
 
       const postDepositTarget = screen.getByTestId('post-deposit-scroll-target');
@@ -338,9 +338,9 @@ describe('LiveSearchSection', () => {
       successes: [],
     });
 
-    expect(screen.getByText('Chanson déposée avec succès')).toBeInTheDocument();
+    expect(screen.getByText('Ta chanson est dans la boîte')).toBeInTheDocument();
     expect(screen.getByText('Déjà déposée')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Partager une chanson' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Déposer une chanson' })).not.toBeInTheDocument();
   });
 
   test('redirects to closed when the box session is required', async () => {
@@ -351,7 +351,7 @@ describe('LiveSearchSection', () => {
 
     const { clearBoxSession } = renderLiveSearchSection();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Déposer une chanson' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Choisir Search song' }));
 
     expect(await screen.findByText('Closed route')).toBeInTheDocument();
@@ -366,10 +366,10 @@ describe('LiveSearchSection', () => {
 
     renderLiveSearchSection();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Déposer une chanson' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Choisir Search song' }));
 
-    expect(await screen.findAllByText('Tu as déjà partagé une chanson dans cette session.')).toHaveLength(2);
+    expect(await screen.findAllByText('Tu as déjà déposé une chanson dans cette session.')).toHaveLength(2);
   });
 
   test('resynchronizes UI from a deposit already exists conflict payload after visual completion', async () => {
@@ -377,7 +377,7 @@ describe('LiveSearchSection', () => {
       {
         status: 409,
         code: 'BOX_SESSION_DEPOSIT_ALREADY_EXISTS',
-        detail: 'Tu as déjà partagé une chanson dans cette session.',
+        detail: 'Tu as déjà déposé une chanson dans cette session.',
         my_deposit: { public_key: 'dep-existing', song: { title: 'Existing song', artist: 'Artist' } },
         successes: [{ name: 'Total', points: 31 }],
         points_balance: 151,
@@ -388,7 +388,7 @@ describe('LiveSearchSection', () => {
 
     const { onDepositCreated, setUser } = renderLiveSearchSection({}, { syncDepositState: true });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Déposer une chanson' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Choisir Search song' }));
 
     await waitFor(() => {
@@ -396,7 +396,7 @@ describe('LiveSearchSection', () => {
     });
     expect(onDepositCreated).not.toHaveBeenCalled();
     expect(setUser).not.toHaveBeenCalled();
-    expect(screen.getByText('Choisis une chanson à partager')).toBeInTheDocument();
+    expect(screen.getByText('Choisis la chanson à déposer')).toBeInTheDocument();
 
     jest.useFakeTimers();
 
@@ -404,7 +404,7 @@ describe('LiveSearchSection', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Terminer animation' }));
 
       await waitFor(() => {
-        expect(screen.queryByText('Choisis une chanson à partager')).not.toBeInTheDocument();
+        expect(screen.queryByText('Choisis la chanson à déposer')).not.toBeInTheDocument();
       });
 
       const postDepositTarget = screen.getByTestId('post-deposit-scroll-target');
@@ -446,7 +446,7 @@ describe('LiveSearchSection', () => {
 
     renderLiveSearchSection();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Partager une chanson' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Déposer une chanson' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Choisir Search song' }));
 
     expect(await screen.findAllByText('Réseau indisponible.')).toHaveLength(2);

--- a/frontend/src/components/Flowbox/discover/MyDeposit.js
+++ b/frontend/src/components/Flowbox/discover/MyDeposit.js
@@ -57,7 +57,7 @@ export default function MyDeposit({
       <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 1 }}>
         <CheckCircleIcon fontSize="medium" />
         <Typography id={MY_DEPOSIT_TITLE_ID} component="h2" variant="h5">
-          Chanson déposée avec succès
+          Ta chanson est dans la boîte
         </Typography>
       </Box>
 
@@ -99,7 +99,7 @@ export default function MyDeposit({
               role={canOpenAchievements ? "button" : undefined}
               tabIndex={canOpenAchievements ? 0 : undefined}
               onKeyDown={handlePointsKeyDown}
-              aria-label={canOpenAchievements ? `Voir les réussites, ${totalPoints} points gagnés` : undefined}
+              aria-label={canOpenAchievements ? `Voir le détail, ${totalPoints} points gagnés` : undefined}
               data-points-balance={pointsBalance ?? undefined}
             >
               <MusicNote />

--- a/frontend/src/components/Flowbox/discover/MyDeposit.test.js
+++ b/frontend/src/components/Flowbox/discover/MyDeposit.test.js
@@ -16,7 +16,7 @@ describe('MyDeposit', () => {
   test('renders deposited song confirmation details', () => {
     render(<MyDeposit deposit={deposit} successes={[{ name: 'Total', points: 42 }]} pointsBalance={5060} depositPointsEarned={84} />);
 
-    expect(screen.getByText('Chanson déposée avec succès')).toBeInTheDocument();
+    expect(screen.getByText('Ta chanson est dans la boîte')).toBeInTheDocument();
     expect(screen.getByText('La chanson')).toBeInTheDocument();
     expect(screen.getByText('Une artiste')).toBeInTheDocument();
     expect(screen.getByRole('img', { name: 'La chanson' })).toHaveAttribute('src', deposit.song.image_url);
@@ -32,7 +32,7 @@ describe('MyDeposit', () => {
   test('does not render points when successes are empty after refresh', () => {
     render(<MyDeposit deposit={deposit} successes={[]} />);
 
-    expect(screen.getByText('Chanson déposée avec succès')).toBeInTheDocument();
+    expect(screen.getByText('Ta chanson est dans la boîte')).toBeInTheDocument();
     expect(screen.queryByText('+0')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /points gagnés/i })).not.toBeInTheDocument();
   });


### PR DESCRIPTION
### Motivation
- Harmoniser le wording utilisateur du flow Flowbox pour le rendre immédiatement compréhensible sans modifier la logique applicative. 
- Utiliser le lexique fourni (ouvrir la boîte, vérifier que tu es près de la boîte, explorer la boîte, déposer une chanson, gagner des points, révéler une chanson, mettre une chanson en avant, répondre à une chanson, la boîte est refermée). 
- Ne toucher qu’aux textes visibles, sans renommer de variables, endpoints, classes CSS ou refactorer la logique.

### Description
- Remplacement de nombreux textes Flowbox côté frontend : onboarding / localisation (`Onboarding.js`, `EnableLocation.js`), header session (`Common/Menu.js`), Discover / LiveSearch / MyDeposit (`Discover.js`, `discover/LiveSearchSection.js`, `discover/MyDeposit.js`), dépôt / révélation (`Common/Deposit/*`), commentaires (`Common/Deposit/comments/DepositComments.js`) et pinned UI (`Flowbox/PinnedSongSection.js`), appliquant le lexique demandé sans modifier la logique.
- Backend : traduction/labels visibles des achievements ajustés dans `box_management/services/deposits/achievements.py` (noms et descriptions visibles mis à jour, clés techniques conservées).
- Tests de wording adaptés (tests `Discover`, `LiveSearchSection`, `PinnedSongSection`, `MyDeposit` modifiés pour matcher les nouveaux libellés) et quelques mocks ajustés pour la synchronisation visuelle de dépôt.
- Ajout du document `docs/flowbox-wording-lexicon.md` contenant le lexique, exemples et règles d’usage.
- Respect strict des contraintes : seuls les libellés visibles ont été modifiés ; variables/props/endpoints/classes techniques restent inchangés.

### Testing
- Build frontend : `npm --prefix frontend run build` — compilation OK; webpack a émis des warnings de taille d’asset (invariants, non liés au wording).
- Tests unitaires ciblés : `npm --prefix frontend test -- --runInBand LiveSearchSection MyDeposit PinnedSongSection Discover` — suites exécutées et passées (tests ciblés verts, 33 tests réussis lors de la validation finale); console contient warnings React préexistants (keys / act) mais aucun échec dû aux changements de wording.
- Vérification de recherche de chaînes incohérentes : `rg -n "Partager une chanson|partager une chanson|Choisis une chanson à partager|Ajoute une chanson|ajoute une chanson|épinglée|Épinglée|Épingler|épingler|débloquer|mission|triche" frontend/src/components/Flowbox frontend/src/components/Common` — résultats restants uniquement techniques/tests non visibles ou acceptés par règle.
- Commit créé: message `Harmonize Flowbox wording` (modifications réparties sur frontend and box_management + `docs/flowbox-wording-lexicon.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff3f95ad188332a914efcc82a78e42)