### PR TITLE
Nudge reveal button for hidden deposit actions

### DIFF
--- a/frontend/assets/scss/3-component/_deposits.scss
+++ b/frontend/assets/scss/3-component/_deposits.scss
@@ -334,15 +334,15 @@
   }
 
   28% {
-    transform: scale(1.08) rotate(-2deg);
+    transform: scale(1.10) rotate(-2.5deg);
   }
 
   55% {
-    transform: scale(1.04) rotate(2deg);
+    transform: scale(1.06) rotate(2.5deg);
   }
 
   78% {
-    transform: scale(1.09) rotate(-1deg);
+    transform: scale(1.11) rotate(-1.5deg);
   }
 
   100% {

--- a/frontend/assets/scss/3-component/_deposits.scss
+++ b/frontend/assets/scss/3-component/_deposits.scss
@@ -125,6 +125,17 @@
   font-size: 26px;
 }
 
+.deposit .deposit_action_button.requires_reveal {
+  opacity: 0.42;
+  cursor: not-allowed;
+}
+
+.deposit .deposit_action_button.requires_reveal .MuiSvgIcon-root,
+.deposit .deposit_action_button.requires_reveal .deposit_action_count,
+.deposit .deposit_action_button.requires_reveal .action_count {
+  opacity: 0.85;
+}
+
 .deposit .deposit_action_group {
   display: flex;
   align-items: center;
@@ -315,6 +326,39 @@
   justify-content: center;
   row-gap: 12px;
   width: 100%;
+}
+
+@keyframes depositRevealNudge {
+  0% {
+    transform: scale(1) rotate(0deg);
+  }
+
+  28% {
+    transform: scale(1.08) rotate(-2deg);
+  }
+
+  55% {
+    transform: scale(1.04) rotate(2deg);
+  }
+
+  78% {
+    transform: scale(1.09) rotate(-1deg);
+  }
+
+  100% {
+    transform: scale(1) rotate(0deg);
+  }
+}
+
+.deposit .deposit_song.is_hidden.is_reveal_nudging .decouvrir {
+  animation: depositRevealNudge 420ms ease-out;
+  transform-origin: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .deposit .deposit_song.is_hidden.is_reveal_nudging .decouvrir {
+    animation: none;
+  }
 }
 
 .deposit .decouvrir {

--- a/frontend/assets/scss/3-component/_deposits.scss
+++ b/frontend/assets/scss/3-component/_deposits.scss
@@ -338,11 +338,11 @@
   }
 
   55% {
-    transform: scale(1.06) rotate(2.5deg);
+    transform: scale(1.13) rotate(2.5deg);
   }
 
   78% {
-    transform: scale(1.13) rotate(-1.5deg);
+    transform: scale(1.14) rotate(-1.5deg);
   }
 
   100% {

--- a/frontend/assets/scss/3-component/_deposits.scss
+++ b/frontend/assets/scss/3-component/_deposits.scss
@@ -334,7 +334,7 @@
   }
 
   28% {
-    transform: scale(1.10) rotate(-2.5deg);
+    transform: scale(1.12) rotate(-2.5deg);
   }
 
   55% {
@@ -342,7 +342,7 @@
   }
 
   78% {
-    transform: scale(1.11) rotate(-1.5deg);
+    transform: scale(1.13) rotate(-1.5deg);
   }
 
   100% {

--- a/frontend/src/components/Common/Deposit/Deposit.js
+++ b/frontend/src/components/Common/Deposit/Deposit.js
@@ -15,7 +15,7 @@ import Slide from "@mui/material/Slide";
 import Snackbar from "@mui/material/Snackbar";
 import SnackbarContent from "@mui/material/SnackbarContent";
 import Typography from "@mui/material/Typography";
-import React, { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import {
@@ -266,13 +266,30 @@ export default function Deposit({
   const [shareSnack, setShareSnack] = useState({ open: false, message: "" });
   const [isSharing, setIsSharing] = useState(false);
   const [authModalConfig, setAuthModalConfig] = useState(null);
-  const [reactionRevealPromptOpen, setReactionRevealPromptOpen] = useState(false);
+  const [revealNudgeToken, setRevealNudgeToken] = useState(0);
+  const revealNudgeCooldownRef = useRef(0);
   const [actionErrorDialog, setActionErrorDialog] = useState({ open: false, title: "Erreur", message: "" });
 
   const openActionErrorDialog = useCallback((title, message, event = null) => {
     blurEventTarget(event);
     blurActiveElement();
     setActionErrorDialog({ open: true, title, message });
+  }, []);
+
+  const nudgeRevealButton = useCallback((event = null) => {
+    event?.stopPropagation?.();
+
+    blurEventTarget(event);
+    blurActiveElement();
+
+    const now = Date.now();
+
+    if (now - revealNudgeCooldownRef.current < 600) {
+      return;
+    }
+
+    revealNudgeCooldownRef.current = now;
+    setRevealNudgeToken((value) => value + 1);
   }, []);
 
   const myReactionEmoji = localDep?.my_reaction?.emoji || null;
@@ -463,11 +480,11 @@ export default function Deposit({
   const toggleCommentsInline = useCallback((event) => {
     event?.stopPropagation?.();
     if (!isRevealed) {
-      openActionErrorDialog("Révèle d’abord cette chanson", "Tu pourras réagir une fois le morceau révélé.", event);
+      nudgeRevealButton(event);
       return;
     }
     setCommentsOpen((prev) => !prev);
-  }, [isRevealed, openActionErrorDialog]);
+  }, [isRevealed, nudgeRevealButton]);
 
   const openReactionSummaryDrawer = useCallback((event) => {
     event?.stopPropagation?.();
@@ -512,7 +529,7 @@ export default function Deposit({
         blurActiveElement();
         setCommentsOpen(true);
       } else {
-        openActionErrorDialog("Révèle d’abord cette chanson", "Tu pourras réagir une fois le morceau révélé.");
+        nudgeRevealButton();
       }
       return;
     }
@@ -524,10 +541,15 @@ export default function Deposit({
     });
 
     if (reactionAction) {
+      if (!isRevealed) {
+        nudgeRevealButton();
+        return;
+      }
+
       blurActiveElement();
       setAddReactionOpen(true);
     }
-  }, [viewer?.id, viewer?.is_guest, localDep?.public_key, location, isRevealed, openActionErrorDialog]);
+  }, [viewer?.id, viewer?.is_guest, localDep?.public_key, location, isRevealed, nudgeRevealButton]);
 
   const showShareFeedback = useCallback((message) => {
     setShareSnack({ open: true, message });
@@ -643,13 +665,12 @@ export default function Deposit({
         <Box className="deposit_action_group reactions_group">
           <Button
             variant="depositInteract"
-            className="deposit_action_button addreaction_button addreaction_icon_button"
+            className={`deposit_action_button addreaction_button addreaction_icon_button${!isRevealed ? " requires_reveal" : ""}`}
+            aria-disabled={!isRevealed}
             onClick={(event) => {
               event.stopPropagation();
               if (!isRevealed) {
-                blurEventTarget(event);
-                blurActiveElement();
-                setReactionRevealPromptOpen(true);
+                nudgeRevealButton(event);
                 return;
               }
               if (!viewer?.id) {
@@ -706,7 +727,8 @@ export default function Deposit({
         {showCommentAction ? (
           <Button
             variant="depositInteract"
-            className="deposit_action_button comments_button"
+            className={`deposit_action_button comments_button${!isRevealed ? " requires_reveal" : ""}`}
+            aria-disabled={!isRevealed}
             onClick={toggleCommentsInline}
             startIcon={<ModeCommentOutlinedIcon />}
             endIcon={
@@ -748,6 +770,7 @@ export default function Deposit({
             onRevealRequest={revealDeposit}
             onSongResolved={handleSongResolved}
             revealCost={revealCost}
+            revealNudgeToken={revealNudgeToken}
           />
 
           {footerSlot}
@@ -887,18 +910,6 @@ export default function Deposit({
         </DialogActions>
       </Dialog>
 
-      <Dialog
-        open={reactionRevealPromptOpen}
-        onClose={() => setReactionRevealPromptOpen(false)}
-      >
-        <DialogTitle>Révèle d’abord cette chanson</DialogTitle>
-        <DialogContent>
-          <Typography variant="body1">Tu pourras réagir une fois le morceau révélé.</Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setReactionRevealPromptOpen(false)}>Compris</Button>
-        </DialogActions>
-      </Dialog>
     </>
   );
 }

--- a/frontend/src/components/Common/Deposit/parts/DepositSong.js
+++ b/frontend/src/components/Common/Deposit/parts/DepositSong.js
@@ -70,12 +70,14 @@ export default function DepositSong({
   onRevealRequest,
   onSongResolved,
   revealCost,
+  revealNudgeToken,
 }) {
   const [playOpen, setPlayOpen] = useState(false);
   const [playSong, setPlaySong] = useState(null);
   const [holdProgress, setHoldProgress] = useState(0);
   const [isHoldingReveal, setIsHoldingReveal] = useState(false);
   const [isRevealLoading, setIsRevealLoading] = useState(false);
+  const [isRevealNudging, setIsRevealNudging] = useState(false);
   const revealHoldFrameRef = useRef(null);
   const revealHoldStartRef = useRef(null);
   const revealHoldTriggeredRef = useRef(false);
@@ -181,6 +183,27 @@ export default function DepositSong({
     }
   }, [isRevealed, resetRevealHold]);
 
+  useEffect(() => {
+    if (!revealNudgeToken) {
+      return undefined;
+    }
+
+    setIsRevealNudging(false);
+
+    const startTimer = window.setTimeout(() => {
+      setIsRevealNudging(true);
+    }, 0);
+
+    const endTimer = window.setTimeout(() => {
+      setIsRevealNudging(false);
+    }, 520);
+
+    return () => {
+      window.clearTimeout(startTimer);
+      window.clearTimeout(endTimer);
+    };
+  }, [revealNudgeToken]);
+
   const renderFloatingReactions = () => {
     if (!floatingEmojiItems.length) {return null;}
 
@@ -256,7 +279,7 @@ export default function DepositSong({
 
   return (
     <Box
-      className={`deposit_song${accentColor ? " has_accent_color" : ""}${isRevealed ? "" : " is_hidden"}${isHoldingReveal ? " is_reveal_holding" : ""}${isRevealLoading ? " is_reveal_loading" : ""}`}
+      className={`deposit_song${accentColor ? " has_accent_color" : ""}${isRevealed ? "" : " is_hidden"}${!isRevealed && isRevealNudging ? " is_reveal_nudging" : ""}${isHoldingReveal ? " is_reveal_holding" : ""}${isRevealLoading ? " is_reveal_loading" : ""}`}
       style={{
         ...(accentColor ? { "--deposit-accent": accentColor } : {}),
         ...(isRevealed ? {} : { "--deposit-reveal-progress": holdProgress }),


### PR DESCRIPTION
### Motivation
- Improve UX for hidden deposits by visually disabling like/comment buttons while keeping them clickable and directing the user’s attention to the reveal CTA instead of showing a blocking dialog.

### Description
- Add `revealNudgeToken` state and `revealNudgeCooldownRef` in `Deposit.js` and implement `nudgeRevealButton` to debounce (600ms) and emit a token when a hidden action is clicked.
- Replace hidden-action dialog/triggers for likes and comments with calls to `nudgeRevealButton`, keep auth-restore flows intact when applicable, and remove the dedicated reaction reveal prompt dialog when no longer needed.
- Make like and comment buttons receive the `requires_reveal` class and `aria-disabled={!isRevealed}` so they look disabled but remain clickable to trigger the nudge.
- Pass `revealNudgeToken` into `DepositSong`, and in `DepositSong.js` add `isRevealNudging` local state + `useEffect` to toggle a `is_reveal_nudging` class briefly (replayable) when the token increments.
- Add SCSS rules in `_deposits.scss` for `.requires_reveal` visual state, `@keyframes depositRevealNudge` (scale + small rotation), `.deposit_song.is_hidden.is_reveal_nudging .decouvrir` animation, and a `prefers-reduced-motion` fallback.

### Testing
- Built frontend: `npm --prefix frontend run build` — succeeded (webpack compiled; only pre-existing bundle-size warnings reported). 
- Linted frontend: `npm --prefix frontend run lint` — failed due to unrelated, pre-existing lint errors across the frontend codebase; changes do not introduce new lint failures specific to the feature.
- Targeted ESLint on modified files: `cd frontend && npx eslint src/components/Common/Deposit/Deposit.js src/components/Common/Deposit/parts/DepositSong.js` — reported existing issues in the repository but confirmed modified files compile and the new logic is present.
- Sanity checks performed: verified `deposit` interactions (hidden/revealed) logic paths were updated, CSS classes added, and animation token is passed and triggers the `is_reveal_nudging` class for the expected duration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032d1d709c8332b3698c611988b50b)