### PR TITLE
Add shared AvatarUploadField and use in register + profile edit

### DIFF
--- a/frontend/src/components/Auth/AuthFlow.test.js
+++ b/frontend/src/components/Auth/AuthFlow.test.js
@@ -1,0 +1,38 @@
+import {
+  AUTH_RETURN_STORAGE_KEY,
+  consumeAuthAction,
+  getAuthSuccessTarget,
+  saveAuthReturnContext,
+} from "./AuthFlow";
+
+describe("AuthFlow", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("conserve pathname + search + hash dans getAuthSuccessTarget", () => {
+    const target = getAuthSuccessTarget({
+      fallback: "/profile",
+      locationState: { from: { pathname: "/messages", search: "?thread=test", hash: "#reply" } },
+    });
+    expect(target).toBe("/messages?thread=test#reply");
+  });
+
+  it("n'utilise pas un contexte auth expiré", () => {
+    window.sessionStorage.setItem(
+      AUTH_RETURN_STORAGE_KEY,
+      JSON.stringify({ returnTo: "/stale", savedAt: Date.now() - (16 * 60 * 1000) })
+    );
+
+    expect(getAuthSuccessTarget({ fallback: "/profile" })).toBe("/profile");
+    expect(window.sessionStorage.getItem(AUTH_RETURN_STORAGE_KEY)).toBeNull();
+  });
+
+  it("nettoie une action stale dans consumeAuthAction", () => {
+    saveAuthReturnContext({ returnTo: "/messages", action: { type: "reply", payload: { id: 1 } } });
+
+    const action = consumeAuthAction({ currentPath: "/profile", actionType: "reply" });
+    expect(action).toBeNull();
+    expect(window.sessionStorage.getItem(AUTH_RETURN_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/frontend/src/components/Auth/AuthPanel.js
+++ b/frontend/src/components/Auth/AuthPanel.js
@@ -12,11 +12,12 @@ import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import React, { useContext, useMemo, useState } from "react";
+import React, { useContext, useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { getCookie } from "../Security/TokensUtils";
 import { UserContext } from "../UserContext";
+import AvatarUploadField from "../UserProfile/AvatarUploadField";
 import { checkUserStatus } from "../UsersUtils";
 import { authenticateProviderUser } from "../Utils/streaming/providerClient";
 
@@ -101,6 +102,7 @@ export default function AuthPanel({
   const [registerErrors, setRegisterErrors] = useState({});
   const [loading, setLoading] = useState(false);
   const [successMessage, setSuccessMessage] = useState("");
+  const [registerAvatarFile, setRegisterAvatarFile] = useState(null);
   const registerUsernameError = registerErrors?.username?.[0] || "";
   const registerEmailError = registerErrors?.email?.[0] || "";
   const registerPassword1Error = registerErrors?.password1?.[0] || "";
@@ -111,6 +113,12 @@ export default function AuthPanel({
   const isGuest = Boolean(user?.is_guest);
   const canClose = typeof onClose === "function";
 
+
+  useEffect(() => {
+    if (tab !== "register" && registerAvatarFile) {
+      setRegisterAvatarFile(null);
+    }
+  }, [tab, registerAvatarFile]);
   const finalizeSuccess = async ({ resultType = null, redirectTo = null } = {}) => {
     try {
       await Promise.race([
@@ -189,9 +197,9 @@ export default function AuthPanel({
     setLoading(true);
     setRegisterErrors({});
     const form = new FormData(event.currentTarget);
-    const profilePicture = form.get("profile_picture");
-    if (!profilePicture || !profilePicture.name) {
-      form.delete("profile_picture");
+    form.delete("profile_picture");
+    if (registerAvatarFile) {
+      form.append("profile_picture", registerAvatarFile);
     }
 
     try {
@@ -207,6 +215,7 @@ export default function AuthPanel({
         return;
       }
       setSuccessMessage("Compte créé avec succès.");
+      setRegisterAvatarFile(null);
       await finalizeSuccess({ resultType: "account_created" });
     } catch (error) {
       setRegisterErrors({
@@ -300,10 +309,14 @@ export default function AuthPanel({
               <TextField required fullWidth name="password2" label="Confirmation du mot de passe" type="password" autoComplete="new-password" error={Boolean(registerPassword2Error)} helperText={registerPassword2Error || " "} />
             </Grid>
           </Grid>
-          <Box>
-            <Typography variant="subtitle2" sx={{ mb: 1 }}>Image de profil</Typography>
-            <input type="file" name="profile_picture" accept=".jpg,.jpeg,.png" />
-          </Box>
+          <AvatarUploadField
+            label="Ajoute une photo de profil"
+            buttonLabel="Choisir une photo"
+            avatarSize={64}
+            inputId="register-avatar-input"
+            disabled={loading}
+            onCroppedFileChange={(file) => setRegisterAvatarFile(file)}
+          />
           {registerGlobalError ? <Alert severity="error">{registerGlobalError}</Alert> : null}
           <Button type="submit" variant="contained" disabled={loading}>
             {loading ? <CircularProgress size={20} /> : "Créer mon compte"}

--- a/frontend/src/components/Auth/AuthPanel.test.js
+++ b/frontend/src/components/Auth/AuthPanel.test.js
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+import { UserContext } from "../UserContext";
+
+import AuthPanel from "./AuthPanel";
+
+const mockNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ pathname: "/auth", search: "", hash: "", state: null }),
+}));
+
+jest.mock("../Security/TokensUtils", () => ({ getCookie: () => "token" }));
+jest.mock("../UsersUtils", () => ({ checkUserStatus: jest.fn().mockResolvedValue(undefined) }));
+jest.mock("../Utils/streaming/providerClient", () => ({ authenticateProviderUser: jest.fn() }));
+
+jest.mock("../UserProfile/AvatarUploadField", () => (props) => (
+  <div>
+    <span>{props.label}</span>
+    <button type="button" onClick={() => props.onCroppedFileChange?.(new File(["x"], "avatar.jpg", { type: "image/jpeg" }), "blob:test")}>mock-crop</button>
+  </div>
+));
+
+function renderAuthPanel() {
+  return render(
+    <UserContext.Provider value={{ user: null, setUser: jest.fn(), setIsAuthenticated: jest.fn() }}>
+      <AuthPanel initialTab="register" />
+    </UserContext.Provider>
+  );
+}
+
+describe("AuthPanel register avatar", () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    window.sessionStorage.clear();
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+  });
+
+  it("affiche le wording et remplace l'input brut", () => {
+    const { container } = renderAuthPanel();
+    expect(screen.getByText("Ajoute une photo de profil")).toBeInTheDocument();
+    expect(container.querySelector('input[type="file"][name="profile_picture"]')).toBeNull();
+  });
+
+  it("envoie profile_picture quand un fichier cropé est fourni", async () => {
+    renderAuthPanel();
+    fireEvent.click(screen.getByRole("button", { name: "mock-crop" }));
+    fireEvent.submit(screen.getByRole("button", { name: "Créer mon compte" }).closest("form"));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const options = global.fetch.mock.calls[0][1];
+    expect(options.body.get("profile_picture")).toBeInstanceOf(File);
+  });
+
+  it("n'envoie pas profile_picture sans fichier", async () => {
+    renderAuthPanel();
+    fireEvent.submit(screen.getByRole("button", { name: "Créer mon compte" }).closest("form"));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const options = global.fetch.mock.calls[0][1];
+    expect(options.body.get("profile_picture")).toBeNull();
+  });
+});

--- a/frontend/src/components/UserProfile/AvatarUploadField.js
+++ b/frontend/src/components/UserProfile/AvatarUploadField.js
@@ -1,0 +1,82 @@
+import Avatar from "@mui/material/Avatar";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import React, { useEffect, useState } from "react";
+
+import AvatarCropperModal from "./AvatarCropperModal";
+
+export default function AvatarUploadField({
+  label,
+  currentImageUrl = "",
+  buttonLabel = "Changer ma photo",
+  disabled = false,
+  inputId = "avatar-upload-input",
+  avatarSize = 72,
+  onCroppedFileChange,
+}) {
+  const [cropOpen, setCropOpen] = useState(false);
+  const [selectedFile, setSelectedFile] = useState(null);
+  const [previewUrl, setPreviewUrl] = useState("");
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    };
+  }, [previewUrl]);
+
+  const displayedImageUrl = previewUrl || currentImageUrl || "";
+
+  const handleFileSelect = (event) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) {return;}
+    setSelectedFile(file);
+    setCropOpen(true);
+  };
+
+  const handleCancelCrop = () => {
+    setCropOpen(false);
+    setSelectedFile(null);
+  };
+
+  const handleConfirmCrop = (blob) => {
+    const nextPreviewUrl = URL.createObjectURL(blob);
+    const nextFile = new File([blob], "avatar.jpg", { type: "image/jpeg" });
+
+    setPreviewUrl((previousUrl) => {
+      if (previousUrl) {
+        URL.revokeObjectURL(previousUrl);
+      }
+      return nextPreviewUrl;
+    });
+
+    setCropOpen(false);
+    setSelectedFile(null);
+    onCroppedFileChange?.(nextFile, nextPreviewUrl, blob);
+  };
+
+  return (
+    <>
+      <Box sx={{ display: "flex", alignItems: "center", gap: "16px" }}>
+        <Avatar src={displayedImageUrl} sx={{ width: avatarSize, height: avatarSize }} />
+        <Box>
+          {label ? <Typography variant="subtitle2" sx={{ mb: 1 }}>{label}</Typography> : null}
+          <label htmlFor={inputId}>
+            <input id={inputId} type="file" accept="image/*" hidden onChange={handleFileSelect} />
+            <Button variant="outlined" component="span" disabled={disabled}>{buttonLabel}</Button>
+          </label>
+        </Box>
+      </Box>
+
+      <AvatarCropperModal
+        open={cropOpen}
+        file={selectedFile}
+        onCancel={handleCancelCrop}
+        onConfirm={handleConfirmCrop}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/UserProfile/UserProfileEdit.js
+++ b/frontend/src/components/UserProfile/UserProfileEdit.js
@@ -1,5 +1,4 @@
 import Alert from "@mui/material/Alert";
-import Avatar from "@mui/material/Avatar";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
@@ -12,7 +11,7 @@ import { getCookie } from "../Security/TokensUtils";
 import { UserContext } from "../UserContext";
 import { checkUserStatus } from "../UsersUtils";
 
-import AvatarCropperModal from "./AvatarCropperModal";
+import AvatarUploadField from "./AvatarUploadField";
 
 
 function getApiErrorMessage(payload, fallbackMessage) {
@@ -32,8 +31,6 @@ export default function UserProfileEdit() {
   const [errorMessage, setErrorMessage] = useState("");
   const navigate = useNavigate();
   const location = useLocation();
-  const [cropOpen, setCropOpen] = useState(false);
-  const [selectedFile, setSelectedFile] = useState(null);
   const ownProfilePath = user?.username ? `/profile/${user.username}` : "/profile";
 
   if (user?.is_guest) {
@@ -51,25 +48,14 @@ export default function UserProfileEdit() {
     );
   }
 
-  const onAvatarChange = (e) => {
-    const file = e.target.files?.[0];
-    if (!file) {return;}
-    setErrorMessage("");
-    setSelectedFile(file);
-    setCropOpen(true);
-  };
-
-  const onConfirmCropped = async (blob) => {
-    setCropOpen(false);
+  const onAvatarCroppedFileChange = async (file, previewUrl) => {
     setSaving(true);
     setErrorMessage("");
     const csrftoken = getCookie("csrftoken");
     const form = new FormData();
-    const namedFile = new File([blob], "avatar.jpg", { type: "image/jpeg" });
-    form.append("profile_picture", namedFile);
+    form.append("profile_picture", file);
 
-    const localUrl = URL.createObjectURL(blob);
-    setUser((prev) => ({ ...(prev || {}), profile_picture_url: localUrl }));
+    setUser((prev) => ({ ...(prev || {}), profile_picture_url: previewUrl }));
 
     try {
       const res = await fetch("/users/change-profile-pic", {
@@ -94,7 +80,6 @@ export default function UserProfileEdit() {
       setErrorMessage("Échec de l’envoi de l’image.");
     } finally {
       setSaving(false);
-      setSelectedFile(null);
     }
   };
 
@@ -139,22 +124,12 @@ export default function UserProfileEdit() {
       <Typography variant="h1">Modifier le profil</Typography>
       {errorMessage ? <Alert severity="error">{errorMessage}</Alert> : null}
 
-      <Box sx={{ display: "flex", alignItems: "center", gap: "16px" }}>
-        <Avatar src={user?.profile_picture_url} alt={user?.username} sx={{ width: 72, height: 72 }} />
-        <label htmlFor="avatar-edit-input">
-          <input id="avatar-edit-input" type="file" accept="image/*" hidden onChange={onAvatarChange} />
-          <Button variant="outlined" component="span" disabled={saving}>Changer ma photo</Button>
-        </label>
-      </Box>
-
-      <AvatarCropperModal
-        open={cropOpen}
-        file={selectedFile}
-        onCancel={() => {
-          setCropOpen(false);
-          setSelectedFile(null);
-        }}
-        onConfirm={onConfirmCropped}
+      <AvatarUploadField
+        currentImageUrl={user?.profile_picture_url}
+        buttonLabel="Changer ma photo"
+        disabled={saving}
+        inputId="avatar-edit-input"
+        onCroppedFileChange={onAvatarCroppedFileChange}
       />
 
       <Box sx={{display:"grid", gap:"12px"}}>

--- a/frontend/src/components/UserProfile/UserProfileEdit.js
+++ b/frontend/src/components/UserProfile/UserProfileEdit.js
@@ -1,6 +1,7 @@
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import CircularProgress from "@mui/material/CircularProgress";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import React, { useContext, useState } from "react";
@@ -149,7 +150,15 @@ export default function UserProfileEdit() {
       </Box>
       <Box className="bottom_fixed" sx={{ display: "flex", gap: "12px", justifyContent: "end" }}>
         <Button sx={{ width: "100%" }} variant="outlined" onClick={() => navigate(ownProfilePath)}>Annuler</Button>
-        <Button sx={{ width: "100%" }} variant="contained" onClick={onSaveUsername} disabled={saving}>Enregistrer</Button>
+        <Button
+          sx={{ width: "100%" }}
+          variant="contained"
+          onClick={onSaveUsername}
+          disabled={saving}
+          startIcon={saving ? <CircularProgress size={16} color="inherit" /> : null}
+        >
+          {saving ? "Enregistrement…" : "Enregistrer"}
+        </Button>
       </Box>
     </Box>
   );


### PR DESCRIPTION
### Motivation
- Replace the raw file input in the register form with the exact crop/preview/upload behavior already used in profile edit. 
- Avoid duplication by extracting the file selection + cropper flow into a reusable component while keeping existing UX (immediate preview, JPEG crop, upload). 

### Description
- Added a new shared component `AvatarUploadField` at `frontend/src/components/UserProfile/AvatarUploadField.js` which reuses `AvatarCropperModal` to manage selection, cropping, preview URL lifecycle (revoking old URLs) and emit a ready-to-send `File` (`avatar.jpg`) via `onCroppedFileChange`.
- Replaced inline avatar flow in `frontend/src/components/UserProfile/UserProfileEdit.js` with `AvatarUploadField` and kept the exact upload behavior: immediate local preview, upload to `/users/change-profile-pic`, `saving` state during upload, server response handling and `checkUserStatus` fallback.
- Replaced the old raw file input in `frontend/src/components/Auth/AuthPanel.js` register tab with `AvatarUploadField`, added `registerAvatarFile` state and updated `handleRegisterSubmit()` to `form.delete("profile_picture")` and `form.append("profile_picture", registerAvatarFile)` only when present, preserving optional photo semantics.
- Added tests: `frontend/src/components/Auth/AuthPanel.test.js` (mocks `AvatarUploadField` to verify wording, removal of old input, append behavior) and `frontend/src/components/Auth/AuthFlow.test.js` (auth return/consume behavior covering pathname+search+hash and stale context/action handling).

### Testing
- Ran targeted unit tests: `cd frontend && npm test -- --runInBand AuthPanel.test.js AuthFlow.test.js` — both test suites passed (2 suites, 6 tests total) ✅.
- Built the frontend bundle: `cd frontend && npm run build` — build completed successfully (webpack compiled with warnings only) ✅.
- Ran linter: `cd frontend && npm run lint` — linter reports pre-existing repository errors/warnings outside the scope of this change; lint did not pass globally (these are preexisting and not introduced by this PR) ⚠️.
- Files modified/added in this PR: `frontend/src/components/UserProfile/AvatarUploadField.js` (new), `frontend/src/components/UserProfile/UserProfileEdit.js` (updated), `frontend/src/components/Auth/AuthPanel.js` (updated), `frontend/src/components/Auth/AuthPanel.test.js` (new), `frontend/src/components/Auth/AuthFlow.test.js` (new).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a133d19f5748332aa113a3a3a79c63a)