### PR TITLE
Flowbox: handle geolocation errors with dedicated French dialogs

### DIFF
--- a/frontend/src/components/Flowbox/Onboarding.js
+++ b/frontend/src/components/Flowbox/Onboarding.js
@@ -26,6 +26,31 @@ function isPermissionDeniedError(error) {
   return error?.code === 1 || /denied/i.test(String(error?.message || ""));
 }
 
+
+function getGeolocationDialogConfig(error) {
+  if (!error || typeof error.code !== "number") {return null;}
+
+  if (error.code === 2) {
+    return {
+      type: "position-unavailable",
+      title: "Position introuvable",
+      message: "Ton navigateur n’arrive pas à récupérer ta position pour le moment. Vérifie que la localisation est activée sur ton téléphone, que ton navigateur y a accès, puis réessaie. Si tu es à l’intérieur, rapproche-toi d’une fenêtre.",
+      retryLabel: "Réessayer",
+    };
+  }
+
+  if (error.code === 3) {
+    return {
+      type: "timeout",
+      title: "Localisation trop lente",
+      message: "La récupération de ta position prend trop de temps. Vérifie que la localisation est activée, garde cette page ouverte quelques secondes, puis réessaie.",
+      retryLabel: "Réessayer",
+    };
+  }
+
+  return null;
+}
+
 function getDeviceOs() {
   const userAgent = navigator?.userAgent || "";
   const platform = navigator?.platform || "";
@@ -112,6 +137,7 @@ export default function Onboarding() {
   const [geoLoading, setGeoLoading] = useState(false);
   const [settingsDialogOpen, setSettingsDialogOpen] = useState(false);
   const [outsideRangeDialogOpen, setOutsideRangeDialogOpen] = useState(false);
+  const [geolocationErrorDialog, setGeolocationErrorDialog] = useState(null);
 
   const boxName = runtime?.box?.name || "Boîte";
   const deviceOs = getDeviceOs();
@@ -133,6 +159,7 @@ export default function Onboarding() {
     setPageError("");
     setSettingsDialogOpen(false);
     setOutsideRangeDialogOpen(false);
+    setGeolocationErrorDialog(null);
 
     try {
       const position = await requestLocationOnce();
@@ -178,15 +205,31 @@ export default function Onboarding() {
         setSettingsDialogOpen(true);
         return;
       }
-      setPageError(error?.message || "Impossible d’ouvrir la boîte.");
+
+      const geolocationDialogConfig = getGeolocationDialogConfig(error);
+      if (geolocationDialogConfig) {
+        setSheetOpen(false);
+        setPageError("");
+        setGeolocationErrorDialog(geolocationDialogConfig);
+        return;
+      }
+
+      setPageError("Impossible de récupérer ta position. Réessaie dans un instant.");
     } finally {
       setGeoLoading(false);
     }
   }, [boxSlug, markFlowboxVisited, navigate, saveVerifiedSession, setUser]);
 
+  const handleRetryGeolocation = useCallback(() => {
+    if (geoLoading) {return;}
+    setGeolocationErrorDialog(null);
+    verifyAndOpenBox();
+  }, [geoLoading, verifyAndOpenBox]);
+
   const handleStart = useCallback(async () => {
     setPageError("");
     setOutsideRangeDialogOpen(false);
+    setGeolocationErrorDialog(null);
     const permissionState = await getLocationPermissionState();
 
     if (permissionState === "granted") {
@@ -282,6 +325,28 @@ export default function Onboarding() {
         <DialogActions>
           <Button variant="light" onClick={() => setSettingsDialogOpen(false)}>
             Fermer
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog
+        open={Boolean(geolocationErrorDialog)}
+        onClose={() => setGeolocationErrorDialog(null)}
+        fullWidth
+        maxWidth="xs"
+      >
+        <DialogTitle>{geolocationErrorDialog?.title}</DialogTitle>
+        <DialogContent>
+          <Typography variant="body1">
+            {geolocationErrorDialog?.message}
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button variant="light" onClick={() => setGeolocationErrorDialog(null)} disabled={geoLoading}>
+            Fermer
+          </Button>
+          <Button variant="contained" onClick={handleRetryGeolocation} disabled={geoLoading}>
+            {geolocationErrorDialog?.retryLabel || "Réessayer"}
           </Button>
         </DialogActions>
       </Dialog>

--- a/frontend/src/components/Flowbox/Onboarding.test.js
+++ b/frontend/src/components/Flowbox/Onboarding.test.js
@@ -103,10 +103,33 @@ describe('Onboarding Flowbox entry', () => {
     restoreLocationApis?.();
   });
 
+
+
+  test('shows french dialog for POSITION_UNAVAILABLE geolocation errors', async () => {
+    Object.defineProperty(navigator, 'geolocation', {
+      configurable: true,
+      value: {
+        getCurrentPosition: jest.fn((success, error) => error({
+          code: 2,
+          message: 'Position update is unavailable',
+        })),
+      },
+    });
+
+    renderOnboarding();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ouvrir la boîte' }));
+
+    expect(await screen.findByRole('heading', { name: 'Position introuvable' })).toBeInTheDocument();
+    expect(screen.getByText(/Ton navigateur n’arrive pas à récupérer ta position/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Réessayer' })).toBeInTheDocument();
+    expect(screen.queryByText('Position update is unavailable')).not.toBeInTheDocument();
+  });
+
   test('navigates to Discover after verify-location succeeds and never to search', async () => {
     const { saveVerifiedSession, markFlowboxVisited, setUser } = renderOnboarding();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Commencer' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Ouvrir la boîte' }));
 
     expect(await screen.findByText('Discover route')).toBeInTheDocument();
     expect(screen.queryByText('Search route')).not.toBeInTheDocument();


### PR DESCRIPTION
### Motivation
- Éviter d’exposer aux utilisateurs les messages natifs en anglais retournés par `navigator.geolocation` et fournir des retours clairs en français pour les cas connus de géolocalisation.
- Gérer proprement les erreurs `POSITION_UNAVAILABLE` (code 2) et `TIMEOUT` (code 3) avec des `Dialog` MUI plutôt que d’afficher `error.message` brut.
- Mettre à jour le test qui recherchait l’ancien libellé du bouton d’entrée afin d’éviter une régression de test.

### Description
- Ajout d’un helper `getGeolocationDialogConfig(error)` qui mappe `error.code === 2` et `error.code === 3` vers des configurations de `Dialog` en français.  
- Ajout du state `geolocationErrorDialog` et insertion d’un `Dialog` MUI affichant `title`, `message`, `Fermer` et `Réessayer`, ouvert quand `geolocationErrorDialog !== null`.  
- Modification du `catch` dans `verifyAndOpenBox` pour conserver le flow existant sur `code === 1` (permission refusée), détecter les configs géoloc (codes 2/3) et ouvrir le dialog correspondant en fermant le sheet/drawer, et utiliser un message générique français pour les erreurs inconnues au lieu de `error.message`.  
- Ajout de `handleRetryGeolocation` qui relance `verifyAndOpenBox` sans recharger la page en respectant `geoLoading`, et correction du test pour utiliser `Ouvrir la boîte` et ajouter une couverture simulant `code: 2` (vérifie le titre français, le contenu et l’absence du message anglais). 

### Testing
- Tests ciblés lancés : depuis la racine `cd frontend && npm test -- Onboarding.test.js`, et la suite a passé avec succès (`2 passed`).  
- Recherche rapide pour validation : `rg -n "getCurrentPosition|Position update|Ouvrir la boîte|Commencer|geolocation|verify-location" frontend/src/components/Flowbox`.  
- Fichiers modifiés : `frontend/src/components/Flowbox/Onboarding.js` et `frontend/src/components/Flowbox/Onboarding.test.js`.  
- Résultat observé : les tests automatisés passent et le nouveau dialog bloque l’affichage des messages bruts navigateur pour les codes 2 et 3, while `code === 1` conserve l’ancien comportement de réglages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1347541dc08332a59f2401ffed7cd5)