### PR TITLE
Implement projection order resolver

### DIFF
--- a/frontend/src/features/projection/orderResolution.js
+++ b/frontend/src/features/projection/orderResolution.js
@@ -1,0 +1,200 @@
+const REMOVED_STATUSES = new Set(["removed", "left", "hidden"]);
+const PLAYED_STATUSES = new Set(["played"]);
+const LOCKED_STATUSES = new Set(["locked"]);
+
+function stableId(value) {
+  return value === null || value === undefined ? "" : String(value);
+}
+
+function cardId(card) {
+  return stableId(card && (card.id || card.cardId || card.appearanceId));
+}
+
+function columnId(card) {
+  return stableId(card && (card.columnId || card.column || "default"));
+}
+
+function isRemoved(card) {
+  return Boolean(card && (card.removed || card.left || card.hidden || REMOVED_STATUSES.has(card.status)));
+}
+
+function isPlayed(card) {
+  return Boolean(card && (card.played || card.playedAt || PLAYED_STATUSES.has(card.status)));
+}
+
+function isLocked(card) {
+  return Boolean(card && (card.locked || card.lockedAt || LOCKED_STATUSES.has(card.status)));
+}
+
+function numberOrInfinity(value) {
+  return Number.isFinite(value) ? value : Infinity;
+}
+
+
+function basePosition(card, fallbackIndex) {
+  return [
+    numberOrInfinity(card.manualOrder),
+    numberOrInfinity(card.orderIndex),
+    numberOrInfinity(card.round),
+    numberOrInfinity(card.roundIndex),
+    numberOrInfinity(card.appearanceIndex),
+    numberOrInfinity(card.baseOrder),
+    fallbackIndex,
+  ];
+}
+
+function compareKeys(left, right) {
+  const size = Math.max(left.length, right.length);
+  for (let index = 0; index < size; index += 1) {
+    const a = left[index] === null || left[index] === undefined ? Infinity : left[index];
+    const b = right[index] === null || right[index] === undefined ? Infinity : right[index];
+    if (a < b) {return -1;}
+    if (a > b) {return 1;}
+  }
+  return 0;
+}
+
+function collectActiveCardsByColumn(state) {
+  const cards = Array.isArray(state && state.cards) ? state.cards : [];
+  return cards.reduce((columns, card, fallbackIndex) => {
+    if (isRemoved(card)) {return columns;}
+    const key = columnId(card);
+    if (!columns[key]) {columns[key] = [];}
+    columns[key].push({ ...card, __fallbackIndex: fallbackIndex });
+    return columns;
+  }, {});
+}
+
+function collectEventCards(events, names) {
+  return events.flatMap((event) => {
+    if (!event || !names.has(event.type)) {return [];}
+    const payload = event.payload || event;
+    return payload.cardIds || payload.appearanceIds || (payload.cardId ? [payload.cardId] : payload.appearanceId ? [payload.appearanceId] : []);
+  }).map(stableId);
+}
+
+function identifyAnchors(context) {
+  const events = Array.isArray(context && context.events) ? context.events : Array.isArray(context && context.transaction && context.transaction.events) ? context.transaction.events : [];
+  const anchors = [];
+  events.forEach((event) => {
+    const payload = (event && event.payload) || event || {};
+    if (!event) {return;}
+    if (["card_moved", "manual_order_changed", "manual_drag"].includes(event.type)) {anchors.push(payload.cardId || payload.appearanceId || payload.id);}
+    if (event.type === "link_created") {anchors.push(payload.anchorTarget || payload.anchorTargetId || payload.targetId || payload.toId);}
+    if (event.type === "conflict_created") {anchors.push(payload.anchorTargetId || payload.anchorTarget || payload.targetId);}
+    if (event.type === "participation_added") {anchors.push(...(payload.newAppearanceIds || payload.appearanceIds || payload.cardIds || []));}
+    if (event.type === "hole_added") {anchors.push(payload.holeId || payload.cardId || payload.appearanceId || payload.id);}
+    if (event.type === "appearance_skipped") {anchors.push(payload.cardId || payload.appearanceId || payload.id);}
+    if (event.type === "plateau_played") {anchors.push(...(payload.targets || payload.cardIds || payload.appearanceIds || []));}
+  });
+  return new Set(anchors.filter(Boolean).map(stableId));
+}
+
+function relationPairs(state, key) {
+  return (Array.isArray(state && state[key]) ? state[key] : []).map((relation) => [
+    stableId(relation.sourceId || relation.fromId || relation.a || relation.leftId || relation.cardId),
+    stableId(relation.targetId || relation.toId || relation.b || relation.rightId || relation.linkedCardId || relation.conflictCardId),
+  ]).filter(([a, b]) => a && b && a !== b);
+}
+
+function resolveOrderAfterTransaction(state, context = {}) {
+  const warnings = [];
+  const byColumn = collectActiveCardsByColumn(state);
+  const anchors = identifyAnchors(context);
+  const links = relationPairs(state, "links");
+  const conflicts = relationPairs(state, "conflicts");
+  const movedDecisionIds = new Set(collectEventCards(Array.isArray(context.events) ? context.events : [], new Set(["appearance_skipped", "replacement_selected", "without_musician_selected"])));
+  const resolvedColumns = {};
+
+  Object.entries(byColumn).forEach(([col, cards]) => {
+    const ids = new Set(cards.map(cardId));
+    const directConflicts = new Set(conflicts.flatMap(([a, b]) => [`${a}\u0000${b}`, `${b}\u0000${a}`]));
+    const parent = {};
+    ids.forEach((id) => { parent[id] = id; });
+    const find = (id) => parent[id] === id ? id : (parent[id] = find(parent[id]));
+    const union = (a, b) => { if (!ids.has(a) || !ids.has(b)) {return;} const ra = find(a); const rb = find(b); if (ra !== rb) { parent[rb] = ra; } };
+    links.forEach(([a, b]) => {
+      if (directConflicts.has(`${a}\u0000${b}`)) {
+        warnings.push({ code: "LINK_CONFLICT_DIRECT", cardIds: [a, b].sort() });
+        return;
+      }
+      union(a, b);
+    });
+    conflicts.forEach(([a, b]) => {
+      const ca = cards.find((card) => cardId(card) === a);
+      const cb = cards.find((card) => cardId(card) === b);
+      if (!ca || !cb) {return;}
+      if ((anchors.has(a) && !isPlayed(cb) && !isLocked(cb)) || (anchors.has(b) && !isPlayed(ca) && !isLocked(ca))) {union(a, b);}
+    });
+
+    const groups = new Map();
+    cards.forEach((card) => {
+      const id = cardId(card);
+      const groupId = (isPlayed(card) || isLocked(card)) ? id : find(id);
+      if (!groups.has(groupId)) {groups.set(groupId, []);}
+      groups.get(groupId).push(card);
+    });
+
+    const units = Array.from(groups.values()).map((members) => {
+      const anchorIds = new Set(members.filter((card) => anchors.has(cardId(card))).map(cardId));
+      const linkedToAnchorIds = new Set();
+      const conflictToAnchorIds = new Set();
+      links.forEach(([a, b]) => {
+        if (anchorIds.has(a)) {linkedToAnchorIds.add(b);}
+        if (anchorIds.has(b)) {linkedToAnchorIds.add(a);}
+      });
+      conflicts.forEach(([a, b]) => {
+        if (anchorIds.has(a)) {conflictToAnchorIds.add(b);}
+        if (anchorIds.has(b)) {conflictToAnchorIds.add(a);}
+      });
+      const memberRank = (card) => {
+        const id = cardId(card);
+        if (anchorIds.has(id)) {return 0;}
+        if (linkedToAnchorIds.has(id)) {return 1;}
+        if (conflictToAnchorIds.has(id)) {return 2;}
+        return 3;
+      };
+      const sortedMembers = [...members].sort((a, b) => memberRank(a) - memberRank(b) || compareKeys(basePosition(a, a.__fallbackIndex), basePosition(b, b.__fallbackIndex)) || cardId(a).localeCompare(cardId(b)));
+      const hasPlayed = sortedMembers.some(isPlayed);
+      const hasLocked = sortedMembers.some(isLocked);
+      const hasAnchor = sortedMembers.some((card) => anchors.has(cardId(card)));
+      const hasDecision = sortedMembers.some((card) => movedDecisionIds.has(cardId(card)) || card.callDecision || card.appearanceSkipped);
+      const minFrozen = Math.min(...sortedMembers.map((card) => isPlayed(card) ? numberOrInfinity(card.playedAtPlateauIndex ?? card.frozenOrderKey) : isLocked(card) ? numberOrInfinity(card.lockedOrderKey ?? card.frozenOrderKey) : Infinity));
+      const minManual = hasAnchor
+        ? Math.min(...sortedMembers.filter((card) => anchors.has(cardId(card))).map((card) => numberOrInfinity(card.manualOrder)))
+        : Math.min(...sortedMembers.map((card) => numberOrInfinity(card.manualOrder)));
+      const minBase = hasAnchor
+        ? sortedMembers.filter((card) => anchors.has(cardId(card))).reduce((best, card) => compareKeys(basePosition(card, card.__fallbackIndex), best) < 0 ? basePosition(card, card.__fallbackIndex) : best, [Infinity])
+        : sortedMembers.reduce((best, card) => compareKeys(basePosition(card, card.__fallbackIndex), best) < 0 ? basePosition(card, card.__fallbackIndex) : best, [Infinity]);
+      return { members: sortedMembers, key: [hasPlayed ? 0 : hasLocked ? 1 : 2, hasPlayed || hasLocked ? minFrozen : Infinity, hasAnchor ? 0 : 1, hasDecision ? 0 : 1, minManual, ...minBase] };
+    });
+
+    resolvedColumns[col] = units.sort((a, b) => compareKeys(a.key, b.key) || cardId(a.members[0]).localeCompare(cardId(b.members[0]))).flatMap((unit) => unit.members);
+  });
+
+  const resolvedCards = Object.values(resolvedColumns).flatMap((cards) => cards).map((card, index) => {
+    const next = { ...card, resolvedOrder: index };
+    delete next.__fallbackIndex;
+    if (isPlayed(next) && (next.playedAtPlateauIndex === null || next.playedAtPlateauIndex === undefined)) {next.playedAtPlateauIndex = index;}
+    if (isLocked(next) && (next.lockedOrderKey === null || next.lockedOrderKey === undefined)) {next.lockedOrderKey = index;}
+    if ((next.frozenOrderKey === null || next.frozenOrderKey === undefined) && (isPlayed(next) || isLocked(next))) {next.frozenOrderKey = index;}
+    return next;
+  });
+
+  return { ...state, cards: resolvedCards, orderWarnings: warnings };
+}
+
+function applyTransactionAndResolve(state, transaction, applyEvent) {
+  const events = Array.isArray(transaction && transaction.events) ? transaction.events : [];
+  const applied = events.reduce((current, event, index) => applyEvent(current, event, { transaction, eventIndex: index }), state);
+  return resolveOrderAfterTransaction(applied, { transaction, events });
+}
+
+module.exports = {
+  resolveOrderAfterTransaction,
+  applyTransactionAndResolve,
+  collectActiveCardsByColumn,
+  identifyAnchors,
+  isPlayed,
+  isLocked,
+};

--- a/frontend/src/features/projection/orderResolution.test.js
+++ b/frontend/src/features/projection/orderResolution.test.js
@@ -1,0 +1,81 @@
+const { resolveOrderAfterTransaction, applyTransactionAndResolve } = require('./orderResolution');
+
+const ids = (state) => state.cards.map((card) => card.id);
+const c = (id, extra = {}) => ({ id, round: 0, appearanceIndex: 0, baseOrder: 0, ...extra });
+
+describe('orderResolution', () => {
+  test('replay identique deux fois', () => {
+    const initial = { cards: [c('B', { manualOrder: 2 }), c('A', { manualOrder: 1 })] };
+    const tx = { events: [{ type: 'card_moved', payload: { cardId: 'B' } }] };
+    const apply = (state) => state;
+    expect(applyTransactionAndResolve(initial, tx, apply)).toEqual(applyTransactionAndResolve(initial, tx, apply));
+  });
+
+  test("ajout D après A' joué", () => {
+    const state = { cards: [
+      c('A', { round: 0, appearanceIndex: 0, played: true, playedAtPlateauIndex: 0 }),
+      c('B', { round: 0, appearanceIndex: 1, played: true, playedAtPlateauIndex: 1 }),
+      c('C', { round: 0, appearanceIndex: 2, played: true, playedAtPlateauIndex: 2 }),
+      c("A'", { round: 1, appearanceIndex: 0, played: true, playedAtPlateauIndex: 3 }),
+      c("B'", { round: 1, appearanceIndex: 1 }),
+      c("C'", { round: 1, appearanceIndex: 2 }),
+      c('D', { round: 0, appearanceIndex: 3 }),
+      c("D'", { round: 1, appearanceIndex: 3 }),
+    ] };
+    expect(ids(resolveOrderAfterTransaction(state))).toEqual(['A', 'B', 'C', "A'", 'D', "B'", "C'", "D'"]);
+  });
+
+  test('drag avec conflict, target mobile', () => {
+    const state = { cards: [c('A', { manualOrder: 20 }), c('B', { manualOrder: 10 }), c('C', { manualOrder: 30 })], conflicts: [{ sourceId: 'A', targetId: 'B' }] };
+    expect(ids(resolveOrderAfterTransaction(state, { events: [{ type: 'card_moved', payload: { cardId: 'A' } }] }))).toEqual(['A', 'B', 'C']);
+  });
+
+  test('drag avec conflict, target played', () => {
+    const state = { cards: [c('B', { played: true, playedAtPlateauIndex: 0 }), c('A', { manualOrder: 0 })], conflicts: [{ sourceId: 'A', targetId: 'B' }] };
+    expect(ids(resolveOrderAfterTransaction(state, { events: [{ type: 'card_moved', payload: { cardId: 'A' } }] }))).toEqual(['B', 'A']);
+  });
+
+  test('drag avec conflict, target locked', () => {
+    const state = { cards: [c('B', { locked: true, lockedOrderKey: 0 }), c('A', { manualOrder: 0 })], conflicts: [{ sourceId: 'A', targetId: 'B' }] };
+    expect(ids(resolveOrderAfterTransaction(state, { events: [{ type: 'card_moved', payload: { cardId: 'A' } }] }))).toEqual(['B', 'A']);
+  });
+
+  test('drag d’une card linkée', () => {
+    const state = { cards: [c('A', { manualOrder: 20 }), c('C', { manualOrder: 10 }), c('B', { manualOrder: 30 })], links: [{ sourceId: 'A', targetId: 'C' }] };
+    expect(ids(resolveOrderAfterTransaction(state, { events: [{ type: 'card_moved', payload: { cardId: 'A' } }] }))).toEqual(['A', 'C', 'B']);
+  });
+
+  test('drag d’une card linkée avec conflict externe', () => {
+    const state = { cards: [c('A', { manualOrder: 30 }), c('C', { manualOrder: 10 }), c('B', { manualOrder: 20 })], links: [{ sourceId: 'A', targetId: 'C' }], conflicts: [{ sourceId: 'A', targetId: 'B' }] };
+    expect(ids(resolveOrderAfterTransaction(state, { events: [{ type: 'card_moved', payload: { cardId: 'A' } }] }))).toEqual(['A', 'C', 'B']);
+  });
+
+  test('link direct refusé si conflict direct', () => {
+    const state = { cards: [c('B', { manualOrder: 10 }), c('A', { manualOrder: 20 })], links: [{ sourceId: 'A', targetId: 'B' }], conflicts: [{ sourceId: 'A', targetId: 'B' }] };
+    const resolved = resolveOrderAfterTransaction(state);
+    expect(ids(resolved)).toEqual(['B', 'A']);
+    expect(resolved.orderWarnings).toEqual([{ code: 'LINK_CONFLICT_DIRECT', cardIds: ['A', 'B'] }]);
+  });
+
+  test('lock empêchant une insertion de passer devant', () => {
+    const state = { cards: [c('L', { locked: true, lockedOrderKey: 0 }), c('N', { manualOrder: -1 })] };
+    expect(ids(resolveOrderAfterTransaction(state))).toEqual(['L', 'N']);
+  });
+
+  test('link_removed et conflict_removed ne provoquent pas de retour magique', () => {
+    const state = { cards: [c('A', { manualOrder: 0 }), c('B', { manualOrder: 1 }), c('C', { manualOrder: 2 })], links: [], conflicts: [] };
+    expect(ids(resolveOrderAfterTransaction(state, { events: [{ type: 'link_removed', payload: { sourceId: 'A', targetId: 'B' } }, { type: 'conflict_removed', payload: { sourceId: 'B', targetId: 'C' } }] }))).toEqual(['A', 'B', 'C']);
+  });
+
+  test('round_revealed respecte played/locked/manual/link/conflict', () => {
+    const state = { cards: [
+      c('P', { played: true, playedAtPlateauIndex: 0, round: 1 }),
+      c('L', { locked: true, lockedOrderKey: 1, round: 1 }),
+      c('A', { manualOrder: 5, round: 2 }),
+      c('C', { manualOrder: 6, round: 0 }),
+      c('B', { manualOrder: 7, round: 0 }),
+      c('R', { round: 0, appearanceIndex: 0 }),
+    ], links: [{ sourceId: 'A', targetId: 'C' }], conflicts: [{ sourceId: 'A', targetId: 'B' }] };
+    expect(ids(resolveOrderAfterTransaction(state, { events: [{ type: 'round_revealed', payload: { round: 2 } }, { type: 'card_moved', payload: { cardId: 'A' } }] }))).toEqual(['P', 'L', 'A', 'C', 'B', 'R']);
+  });
+});


### PR DESCRIPTION
### Motivation
- Implement a pure, deterministic frontend engine to compute stable card order after each transaction according to the project’s order-resolution hierarchy and non-negotiable constraints (no randomness, no Date.now(), no React/DOM/storage deps). 
- Ensure played/locked cards remain frozen, links and conflicts are resolved deterministically, and replaying the same event log always yields the same order. 
- Fix the regression where a new appearance could incorrectly interleave before later appearances (example: ensure D is inserted after A' in the A,B,C / A',B',C' scenario). 

### Description
- Added `frontend/src/features/projection/orderResolution.js` which provides `resolveOrderAfterTransaction(state, context)` and `applyTransactionAndResolve(state, transaction, applyEvent)` plus pure helper exports for collection and anchor detection. 
- The resolver implements: active-card collection by column, anchor identification from transaction events, relation extraction (`links` / `conflicts`), union-find grouping for linked units (with direct link/conflict detection and deterministic warnings), and a stable sort key implementing the specified hierarchy including played/locked freezing. 
- When played or locked cards are encountered the resolver sets stable frozen fields (`playedAtPlateauIndex` / `lockedOrderKey` / `frozenOrderKey`) so their positions remain reproducible and reconstructable from the event log. 
- Added unit tests `frontend/src/features/projection/orderResolution.test.js` covering deterministic replay, the A/A' insertion case, various link/conflict/locked/played scenarios, removal stability and `round_revealed` behavior. 

### Testing
- Ran the new unit tests with `npx jest --runInBand src/features/projection/orderResolution.test.js` and all tests passed (11/11). 
- Linted the new module with `npx eslint src/features/projection/orderResolution.js` which produced only existing complexity warnings and no errors for the new file. 
- Built the frontend with `npm run build` which compiled successfully and produced the usual webpack bundle-size warnings. 
- Files modified: `frontend/src/features/projection/orderResolution.js` and `frontend/src/features/projection/orderResolution.test.js`.
- Commands executed during validation: `npx jest --runInBand src/features/projection/orderResolution.test.js`, `npx eslint src/features/projection/orderResolution.js`, and `npm run build`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31c1efed048332a03c0572af574343)