### PR TITLE
Order resolution: frozen-boundary handling, deterministic warnings, event anchors and event-log projection

### DIFF
--- a/frontend/src/features/projection/orderResolution.js
+++ b/frontend/src/features/projection/orderResolution.js
@@ -1,6 +1,8 @@
 const REMOVED_STATUSES = new Set(["removed", "left", "hidden"]);
 const PLAYED_STATUSES = new Set(["played"]);
 const LOCKED_STATUSES = new Set(["locked"]);
+const MANUAL_REORDER_EVENT_TYPES = new Set(["card_moved", "manual_order_changed", "manual_drag", "appearance_moved_between"]);
+const CALL_DECISION_EVENT_TYPES = new Set(["appearance_skipped", "appearance_replaced", "replacement_selected", "without_musician_selected"]);
 
 function stableId(value) {
   return value === null || value === undefined ? "" : String(value);
@@ -30,6 +32,28 @@ function numberOrInfinity(value) {
   return Number.isFinite(value) ? value : Infinity;
 }
 
+function frozenOrderKey(card) {
+  if (isPlayed(card)) {return numberOrInfinity(card.playedAtPlateauIndex ?? card.frozenOrderKey ?? card.__fallbackIndex);}
+  if (isLocked(card)) {return numberOrInfinity(card.lockedOrderKey ?? card.frozenOrderKey ?? card.__fallbackIndex);}
+  return Infinity;
+}
+
+function withCapturedFrozenOrder(card, fallbackIndex) {
+  const next = { ...card, __fallbackIndex: fallbackIndex };
+  if (isPlayed(next) && (next.playedAtPlateauIndex === null || next.playedAtPlateauIndex === undefined)) {next.playedAtPlateauIndex = fallbackIndex;}
+  if (isLocked(next) && (next.lockedOrderKey === null || next.lockedOrderKey === undefined)) {next.lockedOrderKey = fallbackIndex;}
+  if ((next.frozenOrderKey === null || next.frozenOrderKey === undefined) && (isPlayed(next) || isLocked(next))) {next.frozenOrderKey = fallbackIndex;}
+  return next;
+}
+
+function warningIdentity(warning) {
+  return `${warning.code}:${(warning.cardIds || [warning.cardId, warning.anchorId].filter(Boolean)).join(",")}`;
+}
+
+function pushOrderWarning(warnings, warning) {
+  const key = warningIdentity(warning);
+  if (!warnings.some((item) => warningIdentity(item) === key)) {warnings.push(warning);}
+}
 
 function basePosition(card, fallbackIndex) {
   return [
@@ -60,7 +84,7 @@ function collectActiveCardsByColumn(state) {
     if (isRemoved(card)) {return columns;}
     const key = columnId(card);
     if (!columns[key]) {columns[key] = [];}
-    columns[key].push({ ...card, __fallbackIndex: fallbackIndex });
+    columns[key].push(withCapturedFrozenOrder(card, fallbackIndex));
     return columns;
   }, {});
 }
@@ -69,25 +93,46 @@ function collectEventCards(events, names) {
   return events.flatMap((event) => {
     if (!event || !names.has(event.type)) {return [];}
     const payload = event.payload || event;
-    return payload.cardIds || payload.appearanceIds || (payload.cardId ? [payload.cardId] : payload.appearanceId ? [payload.appearanceId] : []);
+    return payloadValues(payload, ["cardIds", "appearanceIds", "replacementAppearanceIds", "cardId", "appearanceId", "replacementAppearanceId", "targetAppearanceId", "id"]);
   }).map(stableId);
+}
+
+function firstPayloadValue(payload, names) {
+  return names.map((name) => payload[name]).find((value) => value !== null && value !== undefined);
+}
+
+function payloadValues(payload, names) {
+  const value = firstPayloadValue(payload, names);
+  return Array.isArray(value) ? value : value ? [value] : [];
+}
+
+function manualReorderAnchor(payload) {
+  return firstPayloadValue(payload, ["cardId", "appearanceId", "id", "movedAppearanceId", "movedCardId"]);
+}
+
+const EVENT_ANCHOR_READERS = {
+  link_created: (payload) => payloadValues(payload, ["anchorTarget", "anchorTargetId", "targetId", "toId"]),
+  conflict_created: (payload) => payloadValues(payload, ["anchorTargetId", "anchorTarget", "targetId"]),
+  participation_added: (payload) => payloadValues(payload, ["newAppearanceIds", "appearanceIds", "cardIds"]).slice(0, 1),
+  hole_added: (payload) => payloadValues(payload, ["holeId", "cardId", "appearanceId", "id"]),
+  appearance_skipped: (payload) => payloadValues(payload, ["cardId", "appearanceId", "id"]),
+  appearance_replaced: (payload) => payloadValues(payload, ["replacementAppearanceId", "appearanceId", "cardId", "targetAppearanceId", "id"]),
+  replacement_selected: (payload) => payloadValues(payload, ["replacementAppearanceId", "appearanceId", "cardId", "targetAppearanceId", "id"]),
+  without_musician_selected: (payload) => payloadValues(payload, ["appearanceId", "cardId", "targetAppearanceId", "id"]),
+  plateau_played: (payload) => payloadValues(payload, ["targets", "cardIds", "appearanceIds"]),
+};
+
+function eventAnchors(event) {
+  if (!event) {return [];}
+  const payload = event.payload || event;
+  if (MANUAL_REORDER_EVENT_TYPES.has(event.type)) {return payloadValues({ anchor: manualReorderAnchor(payload) }, ["anchor"]);}
+  const reader = EVENT_ANCHOR_READERS[event.type];
+  return reader ? reader(payload) : [];
 }
 
 function identifyAnchors(context) {
   const events = Array.isArray(context && context.events) ? context.events : Array.isArray(context && context.transaction && context.transaction.events) ? context.transaction.events : [];
-  const anchors = [];
-  events.forEach((event) => {
-    const payload = (event && event.payload) || event || {};
-    if (!event) {return;}
-    if (["card_moved", "manual_order_changed", "manual_drag"].includes(event.type)) {anchors.push(payload.cardId || payload.appearanceId || payload.id);}
-    if (event.type === "link_created") {anchors.push(payload.anchorTarget || payload.anchorTargetId || payload.targetId || payload.toId);}
-    if (event.type === "conflict_created") {anchors.push(payload.anchorTargetId || payload.anchorTarget || payload.targetId);}
-    if (event.type === "participation_added") {anchors.push(...(payload.newAppearanceIds || payload.appearanceIds || payload.cardIds || []));}
-    if (event.type === "hole_added") {anchors.push(payload.holeId || payload.cardId || payload.appearanceId || payload.id);}
-    if (event.type === "appearance_skipped") {anchors.push(payload.cardId || payload.appearanceId || payload.id);}
-    if (event.type === "plateau_played") {anchors.push(...(payload.targets || payload.cardIds || payload.appearanceIds || []));}
-  });
-  return new Set(anchors.filter(Boolean).map(stableId));
+  return new Set(events.flatMap(eventAnchors).filter(Boolean).map(stableId));
 }
 
 function relationPairs(state, key) {
@@ -103,19 +148,60 @@ function resolveOrderAfterTransaction(state, context = {}) {
   const anchors = identifyAnchors(context);
   const links = relationPairs(state, "links");
   const conflicts = relationPairs(state, "conflicts");
-  const movedDecisionIds = new Set(collectEventCards(Array.isArray(context.events) ? context.events : [], new Set(["appearance_skipped", "replacement_selected", "without_musician_selected"])));
+  const movedDecisionIds = new Set(collectEventCards(Array.isArray(context.events) ? context.events : [], CALL_DECISION_EVENT_TYPES));
   const resolvedColumns = {};
 
   Object.entries(byColumn).forEach(([col, cards]) => {
     const ids = new Set(cards.map(cardId));
     const directConflicts = new Set(conflicts.flatMap(([a, b]) => [`${a}\u0000${b}`, `${b}\u0000${a}`]));
+    const cardsById = new Map(cards.map((card) => [cardId(card), card]));
+    const warnFrozenBlockedAnchor = (code, anchorId, frozenId) => pushOrderWarning(warnings, { code, anchorId, cardId: frozenId });
+
+    cards.forEach((card) => {
+      const id = cardId(card);
+      if (!anchors.has(id) || isPlayed(card) || isLocked(card)) {return;}
+      const desiredPosition = numberOrInfinity(card.manualOrder ?? card.orderIndex);
+      if (desiredPosition === Infinity) {return;}
+      cards.forEach((candidate) => {
+        const candidateId = cardId(candidate);
+        if (candidateId !== id && (isPlayed(candidate) || isLocked(candidate)) && desiredPosition < frozenOrderKey(candidate)) {
+          warnFrozenBlockedAnchor("FROZEN_BOUNDARY_BLOCKED", id, candidateId);
+        }
+      });
+    });
+
+    links.forEach(([a, b]) => {
+      const ca = cardsById.get(a);
+      const cb = cardsById.get(b);
+      if (anchors.has(a) && cb && (isPlayed(cb) || isLocked(cb))) {warnFrozenBlockedAnchor("LINKED_CARD_FROZEN", a, b);}
+      if (anchors.has(b) && ca && (isPlayed(ca) || isLocked(ca))) {warnFrozenBlockedAnchor("LINKED_CARD_FROZEN", b, a);}
+    });
+
+    conflicts.forEach(([a, b]) => {
+      const ca = cardsById.get(a);
+      const cb = cardsById.get(b);
+      if (anchors.has(a) && cb && (isPlayed(cb) || isLocked(cb))) {warnFrozenBlockedAnchor("CONFLICT_TARGET_FROZEN", a, b);}
+      if (anchors.has(b) && ca && (isPlayed(ca) || isLocked(ca))) {warnFrozenBlockedAnchor("CONFLICT_TARGET_FROZEN", b, a);}
+    });
+
     const parent = {};
     ids.forEach((id) => { parent[id] = id; });
     const find = (id) => parent[id] === id ? id : (parent[id] = find(parent[id]));
     const union = (a, b) => { if (!ids.has(a) || !ids.has(b)) {return;} const ra = find(a); const rb = find(b); if (ra !== rb) { parent[rb] = ra; } };
+    const componentContains = (root, id) => ids.has(id) && find(id) === root;
+    const componentConflict = (leftRoot, rightRoot) => conflicts.find(([x, y]) =>
+      (componentContains(leftRoot, x) && componentContains(rightRoot, y)) ||
+      (componentContains(leftRoot, y) && componentContains(rightRoot, x))
+    );
     links.forEach(([a, b]) => {
       if (directConflicts.has(`${a}\u0000${b}`)) {
-        warnings.push({ code: "LINK_CONFLICT_DIRECT", cardIds: [a, b].sort() });
+        pushOrderWarning(warnings, { code: "LINK_CONFLICT_DIRECT", cardIds: [a, b].sort() });
+        return;
+      }
+      if (!ids.has(a) || !ids.has(b)) {return;}
+      const conflict = componentConflict(find(a), find(b));
+      if (conflict) {
+        pushOrderWarning(warnings, { code: "LINK_CONFLICT_TRANSITIVE", cardIds: conflict.slice().sort(), linkCardIds: [a, b].sort() });
         return;
       }
       union(a, b);
@@ -158,15 +244,21 @@ function resolveOrderAfterTransaction(state, context = {}) {
       const hasPlayed = sortedMembers.some(isPlayed);
       const hasLocked = sortedMembers.some(isLocked);
       const hasAnchor = sortedMembers.some((card) => anchors.has(cardId(card)));
-      const hasDecision = sortedMembers.some((card) => movedDecisionIds.has(cardId(card)) || card.callDecision || card.appearanceSkipped);
-      const minFrozen = Math.min(...sortedMembers.map((card) => isPlayed(card) ? numberOrInfinity(card.playedAtPlateauIndex ?? card.frozenOrderKey) : isLocked(card) ? numberOrInfinity(card.lockedOrderKey ?? card.frozenOrderKey) : Infinity));
+      const hasDecision = sortedMembers.some((card) => movedDecisionIds.has(cardId(card)) || card.callDecision || card.appearanceSkipped || card.appearanceReplaced || card.withoutMusician);
+      const minFrozen = Math.min(...sortedMembers.map(frozenOrderKey));
       const minManual = hasAnchor
         ? Math.min(...sortedMembers.filter((card) => anchors.has(cardId(card))).map((card) => numberOrInfinity(card.manualOrder)))
         : Math.min(...sortedMembers.map((card) => numberOrInfinity(card.manualOrder)));
       const minBase = hasAnchor
         ? sortedMembers.filter((card) => anchors.has(cardId(card))).reduce((best, card) => compareKeys(basePosition(card, card.__fallbackIndex), best) < 0 ? basePosition(card, card.__fallbackIndex) : best, [Infinity])
         : sortedMembers.reduce((best, card) => compareKeys(basePosition(card, card.__fallbackIndex), best) < 0 ? basePosition(card, card.__fallbackIndex) : best, [Infinity]);
-      return { members: sortedMembers, key: [hasPlayed ? 0 : hasLocked ? 1 : 2, hasPlayed || hasLocked ? minFrozen : Infinity, hasAnchor ? 0 : 1, hasDecision ? 0 : 1, minManual, ...minBase] };
+      const minFallbackIndex = Math.min(...sortedMembers.map((card) => numberOrInfinity(card.__fallbackIndex)));
+      const shouldRespectFrozenBoundary = (key) => hasAnchor || hasDecision || minFallbackIndex > key;
+      const blockingFrozenKeys = sortedMembers.some((card) => isPlayed(card) || isLocked(card)) || minManual === Infinity
+        ? []
+        : cards.map(frozenOrderKey).filter((key) => key !== Infinity && minManual < key && shouldRespectFrozenBoundary(key));
+      const effectiveManual = blockingFrozenKeys.length ? Math.max(minManual, Math.max(...blockingFrozenKeys) + 0.1) : minManual;
+      return { members: sortedMembers, key: [hasPlayed || hasLocked ? minFrozen : effectiveManual, hasPlayed ? 0 : hasLocked ? 1 : 2, hasAnchor ? 0 : 1, hasDecision ? 0 : 1, minManual, ...minBase] };
     });
 
     resolvedColumns[col] = units.sort((a, b) => compareKeys(a.key, b.key) || cardId(a.members[0]).localeCompare(cardId(b.members[0]))).flatMap((unit) => unit.members);
@@ -177,22 +269,47 @@ function resolveOrderAfterTransaction(state, context = {}) {
     delete next.__fallbackIndex;
     if (isPlayed(next) && (next.playedAtPlateauIndex === null || next.playedAtPlateauIndex === undefined)) {next.playedAtPlateauIndex = index;}
     if (isLocked(next) && (next.lockedOrderKey === null || next.lockedOrderKey === undefined)) {next.lockedOrderKey = index;}
-    if ((next.frozenOrderKey === null || next.frozenOrderKey === undefined) && (isPlayed(next) || isLocked(next))) {next.frozenOrderKey = index;}
+    if ((next.frozenOrderKey === null || next.frozenOrderKey === undefined) && (isPlayed(next) || isLocked(next))) {next.frozenOrderKey = frozenOrderKey(next) === Infinity ? index : frozenOrderKey(next);}
     return next;
   });
 
   return { ...state, cards: resolvedCards, orderWarnings: warnings };
 }
 
+function transactionEvents(transaction) {
+  if (Array.isArray(transaction && transaction.events)) {return transaction.events;}
+  return transaction && transaction.type ? [transaction] : [];
+}
+
+function isTransactionActive(transaction) {
+  return !(transaction && (transaction.undone || transaction.reverted || transaction.active === false));
+}
+
 function applyTransactionAndResolve(state, transaction, applyEvent) {
-  const events = Array.isArray(transaction && transaction.events) ? transaction.events : [];
+  const events = transactionEvents(transaction);
   const applied = events.reduce((current, event, index) => applyEvent(current, event, { transaction, eventIndex: index }), state);
   return resolveOrderAfterTransaction(applied, { transaction, events });
+}
+
+function projectEventLog(initialState, eventLog, applyEvent) {
+  const transactions = Array.isArray(eventLog) ? eventLog : [];
+  return transactions.reduce((state, transaction, transactionIndex) => {
+    if (!isTransactionActive(transaction)) {return state;}
+    const resolved = applyTransactionAndResolve(state, transaction, (current, event, eventContext) => applyEvent(current, event, {
+      ...eventContext,
+      transactionIndex,
+    }));
+    return {
+      ...resolved,
+      lastResolvedTransactionIndex: transactionIndex,
+    };
+  }, initialState);
 }
 
 module.exports = {
   resolveOrderAfterTransaction,
   applyTransactionAndResolve,
+  projectEventLog,
   collectActiveCardsByColumn,
   identifyAnchors,
   isPlayed,

--- a/frontend/src/features/projection/orderResolution.test.js
+++ b/frontend/src/features/projection/orderResolution.test.js
@@ -1,4 +1,4 @@
-const { resolveOrderAfterTransaction, applyTransactionAndResolve } = require('./orderResolution');
+const { resolveOrderAfterTransaction, applyTransactionAndResolve, projectEventLog } = require('./orderResolution');
 
 const ids = (state) => state.cards.map((card) => card.id);
 const c = (id, extra = {}) => ({ id, round: 0, appearanceIndex: 0, baseOrder: 0, ...extra });
@@ -11,6 +11,207 @@ describe('orderResolution', () => {
     expect(applyTransactionAndResolve(initial, tx, apply)).toEqual(applyTransactionAndResolve(initial, tx, apply));
   });
 
+  test('projectEventLog résout globalement après chaque transaction', () => {
+    const initial = { cards: [c('B', { manualOrder: 0 }), c('A', { manualOrder: 10 })] };
+    const eventLog = [
+      { id: 'tx-1', events: [{ type: 'card_moved', payload: { cardId: 'A', manualOrder: -1 } }] },
+      { id: 'tx-2', events: [{ type: 'plateau_played', payload: { cardIds: ['A'] } }] },
+      { id: 'tx-3', events: [{ type: 'card_moved', payload: { cardId: 'B', manualOrder: -10 } }] },
+    ];
+    const snapshots = [];
+    const apply = (state, event) => {
+      const payload = event.payload || {};
+      if (event.type === 'card_moved') {
+        return { ...state, cards: state.cards.map((card) => card.id === payload.cardId ? { ...card, manualOrder: payload.manualOrder } : card) };
+      }
+      if (event.type === 'plateau_played') {
+        return { ...state, cards: state.cards.map((card) => payload.cardIds.includes(card.id) ? { ...card, played: true } : card) };
+      }
+      return state;
+    };
+    const projected = projectEventLog(initial, eventLog, (state, event, context) => {
+      const next = apply(state, event, context);
+      if (context.eventIndex === eventLog[context.transactionIndex].events.length - 1) {
+        snapshots.push(ids(resolveOrderAfterTransaction(next, { transaction: eventLog[context.transactionIndex], events: eventLog[context.transactionIndex].events })));
+      }
+      return next;
+    });
+
+    expect(snapshots).toEqual([['A', 'B'], ['A', 'B'], ['A', 'B']]);
+    expect(ids(projected)).toEqual(['A', 'B']);
+    expect(projected.cards[0].playedAtPlateauIndex).toBe(0);
+    expect(projected.lastResolvedTransactionIndex).toBe(2);
+  });
+
+  test('projectEventLog rejoue uniquement les transactions actives pour undo et redo', () => {
+    const initial = { cards: [c('A', { manualOrder: 0 }), c('B', { manualOrder: 1 })] };
+    const moveBFirst = { id: 'tx-1', events: [{ type: 'card_moved', payload: { cardId: 'B', manualOrder: -1 } }] };
+    const apply = (state, event) => ({
+      ...state,
+      cards: state.cards.map((card) => card.id === event.payload.cardId ? { ...card, manualOrder: event.payload.manualOrder } : card),
+    });
+
+    const afterMove = projectEventLog(initial, [moveBFirst], apply);
+    const afterUndo = projectEventLog(initial, [{ ...moveBFirst, undone: true }], apply);
+    const afterRedo = projectEventLog(initial, [{ ...moveBFirst, undone: false }], apply);
+
+    expect(ids(afterMove)).toEqual(['B', 'A']);
+    expect(ids(afterUndo)).toEqual(['A', 'B']);
+    expect(afterUndo.lastResolvedTransactionIndex).toBeUndefined();
+    expect(afterRedo).toEqual(afterMove);
+  });
+
+  test('projectEventLog produit le même tableau final à chaque replay', () => {
+    const initial = { cards: [c('C', { manualOrder: 2 }), c('A', { manualOrder: 0 }), c('B', { manualOrder: 1 })] };
+    const eventLog = [
+      { events: [{ type: 'card_moved', payload: { cardId: 'C', manualOrder: -1 } }] },
+      { events: [{ type: 'link_created', payload: { targetId: 'A' } }] },
+    ];
+    const apply = (state, event) => {
+      if (event.type === 'card_moved') {
+        return { ...state, cards: state.cards.map((card) => card.id === event.payload.cardId ? { ...card, manualOrder: event.payload.manualOrder } : card) };
+      }
+      if (event.type === 'link_created') {
+        return { ...state, links: [{ sourceId: 'A', targetId: 'B' }] };
+      }
+      return state;
+    };
+
+    expect(projectEventLog(initial, eventLog, apply)).toEqual(projectEventLog(initial, eventLog, apply));
+  });
+
+  test('plateau_played capture la position courante avant les insertions suivantes', () => {
+    const initial = { cards: [c('B', { manualOrder: 0 }), c('A', { manualOrder: 10 })] };
+    const eventLog = [
+      { events: [{ type: 'plateau_played', payload: { cardIds: ['A'] } }] },
+      { events: [{ type: 'participation_added', payload: { newAppearanceIds: ['D'] } }] },
+    ];
+    const apply = (state, event) => {
+      if (event.type === 'plateau_played') {
+        return { ...state, cards: state.cards.map((card) => event.payload.cardIds.includes(card.id) ? { ...card, played: true } : card) };
+      }
+      if (event.type === 'participation_added') {
+        return { ...state, cards: [...state.cards, c('D', { manualOrder: -10 })] };
+      }
+      return state;
+    };
+
+    const projected = projectEventLog(initial, eventLog, apply);
+
+    expect(ids(projected)).toEqual(['B', 'A', 'D']);
+    expect(projected.cards[1].playedAtPlateauIndex).toBe(1);
+    expect(projected.cards[1].frozenOrderKey).toBe(1);
+    expect(projected.orderWarnings).toEqual([{ code: 'FROZEN_BOUNDARY_BLOCKED', anchorId: 'D', cardId: 'A' }]);
+  });
+
+  test('manual reorder qui tente de passer devant played ou locked produit des warnings déterministes', () => {
+    const state = { cards: [
+      c('P', { played: true, playedAtPlateauIndex: 0 }),
+      c('L', { locked: true, lockedOrderKey: 1 }),
+      c('A', { manualOrder: -1 }),
+    ] };
+
+    const resolved = resolveOrderAfterTransaction(state, { events: [{ type: 'card_moved', payload: { cardId: 'A' } }] });
+
+    expect(ids(resolved)).toEqual(['P', 'L', 'A']);
+    expect(resolved.orderWarnings).toEqual([
+      { code: 'FROZEN_BOUNDARY_BLOCKED', anchorId: 'A', cardId: 'P' },
+      { code: 'FROZEN_BOUNDARY_BLOCKED', anchorId: 'A', cardId: 'L' },
+    ]);
+  });
+
+  test('link avec cible frozen avertit et ne déplace pas la cible', () => {
+    const state = { cards: [c('C', { locked: true, lockedOrderKey: 0 }), c('A', { manualOrder: -1 })], links: [{ sourceId: 'A', targetId: 'C' }] };
+
+    const resolved = resolveOrderAfterTransaction(state, { events: [{ type: 'card_moved', payload: { cardId: 'A' } }] });
+
+    expect(ids(resolved)).toEqual(['C', 'A']);
+    expect(resolved.orderWarnings).toEqual([
+      { code: 'FROZEN_BOUNDARY_BLOCKED', anchorId: 'A', cardId: 'C' },
+      { code: 'LINKED_CARD_FROZEN', anchorId: 'A', cardId: 'C' },
+    ]);
+  });
+
+  test('round_revealed n’insère pas de nouvelle appearance avant un frozen sans warning', () => {
+    const state = { cards: [
+      c('A', { played: true, playedAtPlateauIndex: 0, round: 0 }),
+      c('B', { locked: true, lockedOrderKey: 1, round: 1 }),
+      c('R', { round: 2, appearanceIndex: 0, manualOrder: -1 }),
+    ] };
+
+    const resolved = resolveOrderAfterTransaction(state, { events: [{ type: 'round_revealed', payload: { round: 2 } }] });
+
+    expect(ids(resolved)).toEqual(['A', 'B', 'R']);
+    expect(resolved.orderWarnings).toEqual([]);
+  });
+
+});
+
+describe('orderResolution non-regression', () => {
+  test('regression: participation ajoutée après des cartes jouées du round 2 reste après le dernier frozen', () => {
+    const initial = { cards: [
+      c('A', { round: 0, appearanceIndex: 0 }),
+      c('B', { round: 0, appearanceIndex: 1 }),
+      c('C', { round: 0, appearanceIndex: 2 }),
+      c("A'", { round: 1, appearanceIndex: 0 }),
+      c("B'", { round: 1, appearanceIndex: 1 }),
+      c("C'", { round: 1, appearanceIndex: 2 }),
+    ] };
+    const eventLog = [
+      { events: [{ type: 'plateau_played', payload: { cardIds: ['A', 'B', 'C', "A'"] } }] },
+      { events: [{ type: 'participation_added', payload: { newAppearanceIds: ['D', "D'"] } }] },
+    ];
+    const apply = (state, event) => {
+      if (event.type === 'plateau_played') {
+        return { ...state, cards: state.cards.map((card) => event.payload.cardIds.includes(card.id) ? { ...card, played: true } : card) };
+      }
+      if (event.type === 'participation_added') {
+        return { ...state, cards: [...state.cards, c('D', { round: 0, appearanceIndex: 3 }), c("D'", { round: 1, appearanceIndex: 3 })] };
+      }
+      return state;
+    };
+
+    const projected = projectEventLog(initial, eventLog, apply);
+
+    expect(ids(projected)).toEqual(['A', 'B', 'C', "A'", 'D', "B'", "C'", "D'"]);
+    expect(projectEventLog(initial, eventLog, apply)).toEqual(projected);
+  });
+
+  test('regression: replay mixte undo, link et conflict produit un état et des warnings déterministes', () => {
+    const initial = { cards: [
+      c('A', { manualOrder: 10 }),
+      c('B', { manualOrder: 11 }),
+      c('C', { manualOrder: 30 }),
+    ] };
+    const eventLog = [
+      { events: [{ type: 'link_created', payload: { sourceId: 'A', targetId: 'B' } }] },
+      { events: [{ type: 'link_created', payload: { sourceId: 'A', targetId: 'C' } }] },
+      { events: [{ type: 'conflict_created', payload: { sourceId: 'B', targetId: 'C' } }] },
+      { undone: true, events: [{ type: 'card_moved', payload: { cardId: 'C', manualOrder: -10 } }] },
+      { events: [{ type: 'card_moved', payload: { cardId: 'A', manualOrder: 0 } }] },
+    ];
+    const apply = (state, event) => {
+      if (event.type === 'link_created') {
+        return { ...state, links: [...(state.links || []), { sourceId: event.payload.sourceId, targetId: event.payload.targetId }] };
+      }
+      if (event.type === 'conflict_created') {
+        return { ...state, conflicts: [...(state.conflicts || []), { sourceId: event.payload.sourceId, targetId: event.payload.targetId }] };
+      }
+      if (event.type === 'card_moved') {
+        return { ...state, cards: state.cards.map((card) => card.id === event.payload.cardId ? { ...card, manualOrder: event.payload.manualOrder } : card) };
+      }
+      return state;
+    };
+
+    const projected = projectEventLog(initial, eventLog, apply);
+
+    expect(ids(projected)).toEqual(['A', 'B', 'C']);
+    expect(projected.orderWarnings).toEqual([{ code: 'LINK_CONFLICT_TRANSITIVE', cardIds: ['B', 'C'], linkCardIds: ['A', 'C'] }]);
+    expect(projectEventLog(initial, eventLog, apply)).toEqual(projected);
+  });
+});
+
+describe('orderResolution hierarchy', () => {
   test("ajout D après A' joué", () => {
     const state = { cards: [
       c('A', { round: 0, appearanceIndex: 0, played: true, playedAtPlateauIndex: 0 }),
@@ -23,6 +224,64 @@ describe('orderResolution', () => {
       c("D'", { round: 1, appearanceIndex: 3 }),
     ] };
     expect(ids(resolveOrderAfterTransaction(state))).toEqual(['A', 'B', 'C', "A'", 'D', "B'", "C'", "D'"]);
+  });
+
+  test('appearance_skipped reste une décision d’appel ancrée', () => {
+    const state = { cards: [c('S', { manualOrder: 20 }), c('B', { manualOrder: 30 })] };
+
+    const resolved = resolveOrderAfterTransaction(state, { events: [{ type: 'appearance_skipped', payload: { appearanceId: 'S' } }] });
+
+    expect(ids(resolved)).toEqual(['S', 'B']);
+  });
+
+  test('appearance_replaced utilise la replacementAppearanceId comme anchor de décision', () => {
+    const state = { cards: [c('A', { manualOrder: 20 }), c('R', { manualOrder: 5 }), c('B', { manualOrder: 30 })] };
+
+    const resolved = resolveOrderAfterTransaction(state, { events: [{ type: 'appearance_replaced', payload: { replacementAppearanceId: 'R' } }] });
+
+    expect(ids(resolved)).toEqual(['R', 'A', 'B']);
+  });
+
+  test('replacement_selected est traité comme décision d’appel et suit les links mobiles', () => {
+    const state = { cards: [c('R', { manualOrder: 20 }), c('C', { manualOrder: 10 }), c('B', { manualOrder: 30 })], links: [{ sourceId: 'R', targetId: 'C' }] };
+
+    const resolved = resolveOrderAfterTransaction(state, { events: [{ type: 'replacement_selected', payload: { replacementAppearanceId: 'R' } }] });
+
+    expect(ids(resolved)).toEqual(['R', 'C', 'B']);
+  });
+
+  test('without_musician_selected respecte locked avec warning déterministe', () => {
+    const state = { cards: [c('L', { locked: true, lockedOrderKey: 0 }), c('A', { manualOrder: -1 })] };
+
+    const resolved = resolveOrderAfterTransaction(state, { events: [{ type: 'without_musician_selected', payload: { appearanceId: 'A' } }] });
+
+    expect(ids(resolved)).toEqual(['L', 'A']);
+    expect(resolved.orderWarnings).toEqual([{ code: 'FROZEN_BOUNDARY_BLOCKED', anchorId: 'A', cardId: 'L' }]);
+  });
+
+  test('appearance_moved_between définit l’anchor du déplacement manuel avec conflict mobile', () => {
+    const state = { cards: [c('A', { manualOrder: 20 }), c('B', { manualOrder: 10 }), c('C', { manualOrder: 30 })], conflicts: [{ sourceId: 'A', targetId: 'B' }] };
+
+    const resolved = resolveOrderAfterTransaction(state, { events: [{ type: 'appearance_moved_between', payload: { appearanceId: 'A' } }] });
+
+    expect(ids(resolved)).toEqual(['A', 'B', 'C']);
+  });
+
+  test('manual_order_changed respecte une frontière locked avec warning déterministe', () => {
+    const state = { cards: [c('L', { locked: true, lockedOrderKey: 0 }), c('A', { manualOrder: -1 })] };
+
+    const resolved = resolveOrderAfterTransaction(state, { events: [{ type: 'manual_order_changed', payload: { cardId: 'A' } }] });
+
+    expect(ids(resolved)).toEqual(['L', 'A']);
+    expect(resolved.orderWarnings).toEqual([{ code: 'FROZEN_BOUNDARY_BLOCKED', anchorId: 'A', cardId: 'L' }]);
+  });
+
+  test('manual_drag conserve le follower linké derrière son anchor', () => {
+    const state = { cards: [c('A', { manualOrder: 20 }), c('C', { manualOrder: 10 }), c('B', { manualOrder: 30 })], links: [{ sourceId: 'A', targetId: 'C' }] };
+
+    const resolved = resolveOrderAfterTransaction(state, { events: [{ type: 'manual_drag', payload: { movedCardId: 'A' } }] });
+
+    expect(ids(resolved)).toEqual(['A', 'C', 'B']);
   });
 
   test('drag avec conflict, target mobile', () => {
@@ -50,6 +309,28 @@ describe('orderResolution', () => {
     expect(ids(resolveOrderAfterTransaction(state, { events: [{ type: 'card_moved', payload: { cardId: 'A' } }] }))).toEqual(['A', 'C', 'B']);
   });
 
+
+  test('conflict gagne contre un link transitif incompatible', () => {
+    const state = {
+      cards: [c('A', { manualOrder: 10 }), c('B', { manualOrder: 11 }), c('C', { manualOrder: 30 })],
+      links: [{ sourceId: 'A', targetId: 'B' }, { sourceId: 'A', targetId: 'C' }],
+      conflicts: [{ sourceId: 'B', targetId: 'C' }],
+    };
+
+    const resolved = resolveOrderAfterTransaction(state, { events: [{ type: 'card_moved', payload: { cardId: 'A' } }] });
+
+    expect(ids(resolved)).toEqual(['A', 'B', 'C']);
+    expect(resolved.orderWarnings).toEqual([{ code: 'LINK_CONFLICT_TRANSITIVE', cardIds: ['B', 'C'], linkCardIds: ['A', 'C'] }]);
+  });
+
+  test('conflict direct gagne contre link direct sans warning transitif en double', () => {
+    const state = { cards: [c('B', { manualOrder: 10 }), c('A', { manualOrder: 20 })], links: [{ sourceId: 'A', targetId: 'B' }], conflicts: [{ sourceId: 'A', targetId: 'B' }] };
+
+    const resolved = resolveOrderAfterTransaction(state, { events: [{ type: 'card_moved', payload: { cardId: 'A' } }] });
+
+    expect(ids(resolved)).toEqual(['A', 'B']);
+    expect(resolved.orderWarnings).toEqual([{ code: 'LINK_CONFLICT_DIRECT', cardIds: ['A', 'B'] }]);
+  });
   test('link direct refusé si conflict direct', () => {
     const state = { cards: [c('B', { manualOrder: 10 }), c('A', { manualOrder: 20 })], links: [{ sourceId: 'A', targetId: 'B' }], conflicts: [{ sourceId: 'A', targetId: 'B' }] };
     const resolved = resolveOrderAfterTransaction(state);


### PR DESCRIPTION
### Motivation

- Make order resolution robust around played/locked (frozen) boundaries so manual reorders and links/conflicts produce deterministic warnings and stable ordering. 
- Properly extract anchors from a larger set of event payload shapes so decisions (manual reorders, replacements, skips, etc.) are respected. 
- Add a utility to project an event-log (transactions) incrementally and only replay active transactions to support undo/redo semantics.

### Description

- Add frozen order helpers: `frozenOrderKey`, `withCapturedFrozenOrder` and use them to capture a card's fallback index and compute frozen boundaries deterministically. 
- Compute and deduplicate order warnings via `warningIdentity` and `pushOrderWarning` to avoid repeated/transitive warnings. 
- Expand event anchor extraction with `eventAnchors`, `EVENT_ANCHOR_READERS`, `manualReorderAnchor`, `payloadValues` and `firstPayloadValue` to support many event payload shapes including `appearance_replaced`, `replacement_selected`, `without_musician_selected`, `appearance_moved_between`, `manual_order_changed`, `manual_drag`, `plateau_played`, `link_created`, `conflict_created`, etc. 
- Enhance link/conflict union-find logic with `componentContains`/`componentConflict` checks and emit `LINK_CONFLICT_TRANSITIVE` warnings when links would create incompatible transitive constraints. 
- Adjust unit grouping/ordering to compute `blockingFrozenKeys` and an `effectiveManual` key so insertions respect frozen boundaries unless legitimately allowed. 
- Preserve and assign appropriate `playedAtPlateauIndex`, `lockedOrderKey` and `frozenOrderKey` when resolving final order. 
- Add `projectEventLog`, `transactionEvents` and `isTransactionActive` to replay transactions incrementally, skip undone/reverted transactions, and expose `lastResolvedTransactionIndex` on the projected state. 
- Export `projectEventLog` and add numerous unit tests and scenarios in `orderResolution.test.js` to cover the new behavior and regressions. 

### Testing

- Ran the `orderResolution` unit tests added/updated in `frontend/src/features/projection/orderResolution.test.js` which exercise `projectEventLog`, frozen-boundary warnings, link/conflict interactions, and many event anchor cases. All tests passed. 
- Executed the repository test suite including the modified file (`npm test` / `yarn test`) and observed no regressions in the order resolution tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31c7805a088332beb473ad569cd60a)