### PR TITLE
Align linked appearances by visible plateauIndex in projection

### DIFF
--- a/frontend/src/features/projection/orderResolution.js
+++ b/frontend/src/features/projection/orderResolution.js
@@ -89,6 +89,47 @@ function collectActiveCardsByColumn(state) {
   }, {});
 }
 
+
+function targetKey(target) {
+  if (typeof target === "string" || typeof target === "number") {return stableId(target);}
+  return stableId(target && (target.cardId || target.appearanceId || target.id || target.targetId));
+}
+
+function getVisibleColumns(state) {
+  if (Array.isArray(state && state.columns)) {
+    return state.columns.map((column) => ({
+      ...column,
+      cards: (Array.isArray(column.cards) ? column.cards : []).filter((card) => !isRemoved(card)),
+    }));
+  }
+  const grouped = collectActiveCardsByColumn(state);
+  return Object.entries(grouped).map(([instrumentId, cards]) => ({
+    instrument: { instrumentId },
+    instrumentId,
+    cards,
+  }));
+}
+
+function getCardsForInstrument(state, instrumentId) {
+  const key = stableId(instrumentId);
+  const column = getVisibleColumns(state).find((item) => stableId(item.instrument && item.instrument.instrumentId || item.instrumentId || item.id) === key);
+  return column ? column.cards : [];
+}
+
+function findCardByTarget(state, target) {
+  const key = targetKey(target);
+  return getVisibleColumns(state).flatMap((column) => column.cards).find((card) => targetKey(card) === key);
+}
+
+function getVisiblePlateauIndex(state, target) {
+  const key = targetKey(target);
+  for (const column of getVisibleColumns(state)) {
+    const index = column.cards.findIndex((card) => targetKey(card) === key);
+    if (index !== -1) {return index;}
+  }
+  return -1;
+}
+
 function collectEventCards(events, names) {
   return events.flatMap((event) => {
     if (!event || !names.has(event.type)) {return [];}
@@ -140,6 +181,99 @@ function relationPairs(state, key) {
     stableId(relation.sourceId || relation.fromId || relation.a || relation.leftId || relation.cardId),
     stableId(relation.targetId || relation.toId || relation.b || relation.rightId || relation.linkedCardId || relation.conflictCardId),
   ]).filter(([a, b]) => a && b && a !== b);
+}
+
+
+function relationEndpoint(relation, names) {
+  return stableId(names.map((name) => relation && relation[name]).find((value) => value !== null && value !== undefined));
+}
+
+function activeLinks(state) {
+  return (Array.isArray(state && state.links) ? state.links : []).filter((link) =>
+    link && link.status !== "removed" && link.status !== "deleted" && link.status !== "inactive" && link.status !== "suppressed" && link.active !== false && link.suppressedByConflict !== true
+  ).map((link) => {
+    const sourceId = relationEndpoint(link, ["sourceId", "fromId", "a", "leftId", "cardId"]);
+    const targetId = relationEndpoint(link, ["targetId", "toId", "b", "rightId", "linkedCardId"]);
+    return {
+      ...link,
+      sourceId,
+      targetId,
+      anchorId: targetKey(link.anchorTarget) || stableId(link.anchorTargetId) || stableId(link.anchorId) || sourceId,
+    };
+  }).filter((link) => link.sourceId && link.targetId && link.sourceId !== link.targetId);
+}
+
+function cardColumnLookup(columns) {
+  const lookup = new Map();
+  Object.entries(columns).forEach(([columnKey, cards]) => {
+    cards.forEach((card, index) => lookup.set(cardId(card), { card, columnKey, index }));
+  });
+  return lookup;
+}
+
+function moveCardToPlateauIndex(cards, id, targetIndex) {
+  const fromIndex = cards.findIndex((card) => cardId(card) === id);
+  if (fromIndex === -1) {return cards;}
+  const next = [...cards];
+  const [card] = next.splice(fromIndex, 1);
+  const boundedIndex = Math.max(0, Math.min(targetIndex, next.length));
+  next.splice(boundedIndex, 0, card);
+  return next;
+}
+
+function suppressLinks(state, suppressedKeys) {
+  if (!suppressedKeys.size || !Array.isArray(state && state.links)) {return state && state.links;}
+  return state.links.map((link) => {
+    const sourceId = relationEndpoint(link, ["sourceId", "fromId", "a", "leftId", "cardId"]);
+    const targetId = relationEndpoint(link, ["targetId", "toId", "b", "rightId", "linkedCardId"]);
+    const key = [sourceId, targetId].sort().join("\u0000");
+    return suppressedKeys.has(key) ? { ...link, status: "suppressed", suppressedByConflict: true } : link;
+  });
+}
+
+function resolveActiveLinksInColumns(state, columns, warnings) {
+  const conflicts = relationPairs(state, "conflicts");
+  const directConflicts = new Set(conflicts.flatMap(([a, b]) => [[a, b].sort().join("\u0000")]));
+  let resolvedColumns = Object.fromEntries(Object.entries(columns).map(([key, cards]) => [key, [...cards]]));
+  const suppressedKeys = new Set();
+
+  activeLinks(state).forEach((link) => {
+    const linkKey = [link.sourceId, link.targetId].sort().join("\u0000");
+    if (directConflicts.has(linkKey)) {
+      suppressedKeys.add(linkKey);
+      pushOrderWarning(warnings, { code: "LINK_CONFLICT_DIRECT", cardIds: [link.sourceId, link.targetId].sort() });
+      return;
+    }
+
+    const lookup = cardColumnLookup(resolvedColumns);
+    const source = lookup.get(link.sourceId);
+    const target = lookup.get(link.targetId);
+    if (!source || !target) {return;}
+
+    const anchorId = link.anchorId === link.targetId ? link.targetId : link.sourceId;
+    const followerId = anchorId === link.sourceId ? link.targetId : link.sourceId;
+    const anchor = lookup.get(anchorId);
+    const follower = lookup.get(followerId);
+    if (!anchor || !follower) {return;}
+
+    if (isPlayed(follower.card) || isLocked(follower.card)) {
+      suppressedKeys.add(linkKey);
+      pushOrderWarning(warnings, { code: "LINKED_CARD_FROZEN", anchorId, cardId: followerId });
+      return;
+    }
+    if (anchor.columnKey === follower.columnKey) {return;}
+
+    const nextColumn = moveCardToPlateauIndex(resolvedColumns[follower.columnKey], followerId, anchor.index);
+    const movedFollower = nextColumn.findIndex((card) => cardId(card) === followerId);
+    if (movedFollower !== anchor.index) {
+      suppressedKeys.add(linkKey);
+      pushOrderWarning(warnings, { code: "LINK_PLATEAU_INDEX_UNREACHABLE", cardIds: [link.sourceId, link.targetId].sort() });
+      return;
+    }
+    resolvedColumns = { ...resolvedColumns, [follower.columnKey]: nextColumn };
+  });
+
+  return { columns: resolvedColumns, suppressedLinks: suppressLinks(state, suppressedKeys) };
 }
 
 function resolveOrderAfterTransaction(state, context = {}) {
@@ -264,7 +398,10 @@ function resolveOrderAfterTransaction(state, context = {}) {
     resolvedColumns[col] = units.sort((a, b) => compareKeys(a.key, b.key) || cardId(a.members[0]).localeCompare(cardId(b.members[0]))).flatMap((unit) => unit.members);
   });
 
-  const resolvedCards = Object.values(resolvedColumns).flatMap((cards) => cards).map((card, index) => {
+  const linkResolution = resolveActiveLinksInColumns(state, resolvedColumns, warnings);
+  const finalColumns = linkResolution.columns;
+
+  const resolvedCards = Object.values(finalColumns).flatMap((cards) => cards).map((card, index) => {
     const next = { ...card, resolvedOrder: index };
     delete next.__fallbackIndex;
     if (isPlayed(next) && (next.playedAtPlateauIndex === null || next.playedAtPlateauIndex === undefined)) {next.playedAtPlateauIndex = index;}
@@ -273,7 +410,7 @@ function resolveOrderAfterTransaction(state, context = {}) {
     return next;
   });
 
-  return { ...state, cards: resolvedCards, orderWarnings: warnings };
+  return { ...state, cards: resolvedCards, links: linkResolution.suppressedLinks || state.links, orderWarnings: warnings };
 }
 
 function transactionEvents(transaction) {
@@ -310,6 +447,11 @@ module.exports = {
   resolveOrderAfterTransaction,
   applyTransactionAndResolve,
   projectEventLog,
+  getVisibleColumns,
+  getCardsForInstrument,
+  getVisiblePlateauIndex,
+  findCardByTarget,
+  targetKey,
   collectActiveCardsByColumn,
   identifyAnchors,
   isPlayed,

--- a/frontend/src/features/projection/orderResolution.test.js
+++ b/frontend/src/features/projection/orderResolution.test.js
@@ -360,3 +360,89 @@ describe('orderResolution hierarchy', () => {
     expect(ids(resolveOrderAfterTransaction(state, { events: [{ type: 'round_revealed', payload: { round: 2 } }, { type: 'card_moved', payload: { cardId: 'A' } }] }))).toEqual(['P', 'L', 'A', 'C', 'B', 'R']);
   });
 });
+
+describe('orderResolution links plateauIndex', () => {
+  const card = (id, columnId, extra = {}) => c(id, { columnId, ...extra });
+  const getCardPlateauIndex = (state, instrumentId, cardId) => {
+    const column = state.cards.filter((item) => item.columnId === instrumentId);
+    return column.findIndex((item) => item.id === cardId);
+  };
+  const project = (initial, eventLog) => projectEventLog(initial, eventLog, (state, event) => {
+    const payload = event.payload || {};
+    if (event.type === 'link_created') {
+      return { ...state, links: [...(state.links || []), { sourceId: payload.sourceId, targetId: payload.targetId, anchorTarget: payload.anchorTarget, status: 'active' }] };
+    }
+    if (event.type === 'conflict_created') {
+      return { ...state, conflicts: [...(state.conflicts || []), { sourceId: payload.sourceId, targetId: payload.targetId }] };
+    }
+    if (event.type === 'card_moved') {
+      return { ...state, cards: state.cards.map((item) => item.id === payload.cardId ? { ...item, manualOrder: payload.manualOrder } : item) };
+    }
+    if (event.type === 'without_musician_selected') {
+      return { ...state, cards: [...state.cards, card(payload.holeId, payload.columnId, { manualOrder: payload.manualOrder })], links: [...(state.links || []), { sourceId: payload.appearanceId, targetId: payload.holeId, anchorTarget: payload.appearanceId, status: 'active' }] };
+    }
+    return state;
+  });
+
+  test('link_created aligne deux appearances sur la même ligne visible', () => {
+    const initial = { cards: [card('A', 'chant', { manualOrder: 0 }), card('B', 'chant', { manualOrder: 1 }), card('C', 'chant', { manualOrder: 2 }), card('X', 'guitare', { manualOrder: 0 }), card('Y', 'guitare', { manualOrder: 1 }), card('Z', 'guitare', { manualOrder: 2 })] };
+    const projected = project(initial, [{ events: [{ type: 'link_created', payload: { sourceId: 'B', targetId: 'Z', anchorTarget: 'B' } }] }]);
+    expect(getCardPlateauIndex(projected, 'chant', 'B')).toBe(getCardPlateauIndex(projected, 'guitare', 'Z'));
+  });
+
+  test('link avec colonnes de tailles différentes réorganise autour du follower', () => {
+    const initial = { cards: [card('A', 'chant', { manualOrder: 0 }), card('B', 'chant', { manualOrder: 1 }), card('X', 'guitare', { manualOrder: 0 }), card('Y', 'guitare', { manualOrder: 1 }), card('Z', 'guitare', { manualOrder: 2 }), card('T', 'guitare', { manualOrder: 3 })] };
+    const projected = project(initial, [{ events: [{ type: 'link_created', payload: { sourceId: 'B', targetId: 'T', anchorTarget: 'B' } }] }]);
+    expect(getCardPlateauIndex(projected, 'chant', 'B')).toBe(getCardPlateauIndex(projected, 'guitare', 'T'));
+    expect(projected.cards.filter((item) => item.columnId === 'guitare').map((item) => item.id)).toEqual(['X', 'T', 'Y', 'Z']);
+  });
+
+  test('drag d’une card linkée conserve le groupe au même plateauIndex', () => {
+    const initial = { cards: [card('A', 'chant', { manualOrder: 0 }), card('B', 'chant', { manualOrder: 1 }), card('C', 'guitare', { manualOrder: 0 }), card('D', 'guitare', { manualOrder: 1 })] };
+    const projected = project(initial, [
+      { events: [{ type: 'link_created', payload: { sourceId: 'A', targetId: 'C', anchorTarget: 'A' } }] },
+      { events: [{ type: 'card_moved', payload: { cardId: 'A', manualOrder: 10 } }] },
+    ]);
+    expect(getCardPlateauIndex(projected, 'chant', 'A')).toBe(getCardPlateauIndex(projected, 'guitare', 'C'));
+  });
+
+  test('link ne déplace pas played', () => {
+    const initial = { cards: [card('A', 'chant', { manualOrder: 1 }), card('B', 'chant', { manualOrder: 0 }), card('C', 'guitare', { manualOrder: 0, played: true, playedAtPlateauIndex: 0 }), card('D', 'guitare', { manualOrder: 1 })] };
+    const projected = project(initial, [{ events: [{ type: 'link_created', payload: { sourceId: 'A', targetId: 'C', anchorTarget: 'A' } }] }]);
+    expect(getCardPlateauIndex(projected, 'guitare', 'C')).toBe(0);
+    expect(projected.links[0]).toMatchObject({ status: 'suppressed', suppressedByConflict: true });
+    expect(projected.orderWarnings).toContainEqual({ code: 'LINKED_CARD_FROZEN', anchorId: 'A', cardId: 'C' });
+  });
+
+  test('link ne déplace pas locked', () => {
+    const initial = { cards: [card('A', 'chant', { manualOrder: 1 }), card('B', 'chant', { manualOrder: 0 }), card('C', 'guitare', { manualOrder: 0, locked: true, lockedOrderKey: 0 }), card('D', 'guitare', { manualOrder: 1 })] };
+    const projected = project(initial, [{ events: [{ type: 'link_created', payload: { sourceId: 'A', targetId: 'C', anchorTarget: 'A' } }] }]);
+    expect(getCardPlateauIndex(projected, 'guitare', 'C')).toBe(0);
+    expect(projected.links[0]).toMatchObject({ status: 'suppressed', suppressedByConflict: true });
+  });
+
+  test('conflict gagne contre link et désactive le link affichable', () => {
+    const initial = { cards: [card('A', 'chant', { manualOrder: 0 }), card('C', 'guitare', { manualOrder: 1 })] };
+    const projected = project(initial, [
+      { events: [{ type: 'conflict_created', payload: { sourceId: 'A', targetId: 'C' } }] },
+      { events: [{ type: 'link_created', payload: { sourceId: 'A', targetId: 'C', anchorTarget: 'A' } }] },
+    ]);
+    expect(projected.links[0]).toMatchObject({ status: 'suppressed', suppressedByConflict: true });
+    expect(projected.orderWarnings).toContainEqual({ code: 'LINK_CONFLICT_DIRECT', cardIds: ['A', 'C'] });
+  });
+
+  test('play without aligne le hole et la source', () => {
+    const initial = { cards: [card('A', 'chant', { manualOrder: 1 }), card('B', 'chant', { manualOrder: 0 }), card('X', 'guitare', { manualOrder: 0 }), card('Y', 'guitare', { manualOrder: 1 })] };
+    const projected = project(initial, [{ events: [{ type: 'without_musician_selected', payload: { appearanceId: 'A', holeId: 'A-hole', columnId: 'guitare', manualOrder: 10 } }] }]);
+    expect(getCardPlateauIndex(projected, 'chant', 'A')).toBe(getCardPlateauIndex(projected, 'guitare', 'A-hole'));
+  });
+
+  test('replay déterministe avec link_created et drag linké', () => {
+    const initial = { cards: [card('A', 'chant', { manualOrder: 0 }), card('B', 'chant', { manualOrder: 1 }), card('C', 'guitare', { manualOrder: 0 }), card('D', 'guitare', { manualOrder: 1 })] };
+    const eventLog = [
+      { events: [{ type: 'link_created', payload: { sourceId: 'A', targetId: 'C', anchorTarget: 'A' } }] },
+      { events: [{ type: 'card_moved', payload: { cardId: 'A', manualOrder: 10 } }] },
+    ];
+    expect(project(initial, eventLog)).toEqual(project(initial, eventLog));
+  });
+});


### PR DESCRIPTION
### Motivation
- The existing `link` feature adjusted numeric order keys but did not guarantee linked appearances end up on the same visible row (plateauIndex) because the UI relies on per-column indexes after sorting.  
- Implement a deterministic, visible-index based link resolver so `link_created` truly aligns targets on the same plateau while preserving the existing order resolution hierarchy and frozen/locked/played constraints.

### Description
- Add pure visible-order helpers: `targetKey`, `getVisibleColumns`, `getCardsForInstrument`, `findCardByTarget`, and `getVisiblePlateauIndex` to compute UI-visible column/card positions.  
- Implement active-link resolution primitives: `activeLinks`, `relationEndpoint`, `cardColumnLookup`, `moveCardToPlateauIndex`, `suppressLinks`, and `resolveActiveLinksInColumns`, which align mobile followers to their anchor's plateauIndex, deterministically suppress unusable links, and emit warnings.  
- Integrate the link resolver into `resolveOrderAfterTransaction` so links are applied after per-column ordering and suppressed links are written back into the projected state.  
- Export visible-order helpers for reuse and add plateau-index focused tests that assert the real index in columns rather than only numeric order fields.  
- Files changed: `frontend/src/features/projection/orderResolution.js` and `frontend/src/features/projection/orderResolution.test.js` (tests added covering link_created alignment, uneven column sizes, dragging linked cards, played/locked refusal, conflict precedence, play-without hole alignment, and deterministic replay). 

### Testing
- Ran the projection test suite: `cd frontend && npm test -- --runInBand orderResolution --watchAll=false`, and the projection tests passed (orderResolution suite: 37 tests passed).  
- Built the frontend: `cd frontend && npm run build`, and the build succeeded (webpack compiled with non-blocking bundle-size warnings).  
- Ran full test run: `cd frontend && npm test -- --watchAll=false`, which executed many suites (most passed) but the overall run failed due to an unrelated test environment issue (`ReferenceError: Worker is not defined` from `heic2any` in `AddReactionModal.test.js`), so full-suite green is blocked by that pre-existing test environment problem; the projection/link tests are unaffected and passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31d55b102c8332943350cdbfa1950d)