### PR TITLE
Implement local-first jam projection pipeline, resolver, in-memory localDb and tests

### DIFF
--- a/docs/action-pipeline-audit.md
+++ b/docs/action-pipeline-audit.md
@@ -1,0 +1,92 @@
+# Audit final pipeline actions
+
+## Verdict global
+
+La pipeline Confiture présente dans ce dépôt est alignée avec la séparation attendue :
+
+```txt
+UX / builder de transaction
+→ applyLocalTransaction()
+→ localDb
+→ projectJamState()
+→ applyEvent()
+→ resolveOrderAfterTransaction()
+→ buildColumns()
+→ syncQueue / hydrateFromPayload()
+```
+
+Les fichiers de documentation Confiture cités dans les prompts ne sont pas présents dans ce checkout. Le présent audit documente donc le comportement réel du code ajouté dans `frontend/src/features`.
+
+## Pipeline réelle finale
+
+1. `hydrateFromPayload(jamId, payload)` persiste le payload serveur dans `localDb`.
+2. `localDb` fusionne les transactions serveur et pending par `transactionId` / `id` / `clientTransactionId`.
+3. `reloadFromLocalDb(jamId)` récupère `baseState` + transactions fusionnées.
+4. `projectJamState(baseState, transactions)` rejoue les transactions actives.
+5. `applyEvent()` applique uniquement les faits bruts des events.
+6. `resolveOrderAfterTransaction()` calcule les conséquences d’ordre.
+7. `buildColumns()` expose les colonnes triées selon l’ordre résolu.
+8. `getPendingSyncQueue()` expose les transactions pending restantes.
+
+## Écarts corrigés
+
+- `npm test -- --run` passait `--run` directement à Jest, qui ne supporte pas cette option. Le script `frontend/runJest.js` filtre maintenant cet argument tout en conservant les autres filtres de test.
+- Les relations `link` / `conflict` supprimées sont ignorées par le resolver au lieu de rester des contraintes actives.
+- `buildColumns()` expose maintenant `column.instrument.instrumentId`, utilisé par les assertions de plateau index visible.
+
+## Écarts restants
+
+- Les builders UX réels (`buildLinkModeTransaction.js`, `buildMoveCardTransaction.js`, etc.) ne sont pas présents dans ce checkout. Les tests pipeline utilisent donc des builders de test déterministes.
+- IndexedDB/Dexie réel n’est pas présent ; `localDb.js` est une implémentation locale en mémoire qui reproduit les règles de merge nécessaires aux tests.
+- Aucun endpoint backend d’append/sync Confiture n’est présent dans ce checkout.
+
+## Tableau par action
+
+| Action | Builder | Event type | applyEvent | Resolver | Tests | Verdict |
+|---|---|---|---|---|---|---|
+| Mise à jour participant | Builder de test `tx()` | `participant_updated` | Met à jour `participants` | Pas d’impact ordre | `jamPipeline.test.js` | OK |
+| Ajout participation | Builder de test `tx()` | `participation_added` | Ajoute les appearances/cards | Place selon round/base et pins | `jamPipeline.test.js`, `orderResolution.test.js` | OK |
+| Drag / move | Builder de test `tx()` | `appearance_moved_between` | Stocke l’intention/manualOrder | Applique anchor/manual sans déplacer played/locked | `jamPipeline.test.js`, `orderResolution.test.js` | OK |
+| Reveal round | Builder de test `tx()` | `round_revealed` | Ajoute le round révélé | Aucun tri final hors resolver | `jamPipeline.test.js` | OK |
+| Played | Builder de test `tx()` | `plateau_played` | Marque `played` | Fige `playedAtPlateauIndex` | `jamPipeline.test.js`, `orderResolution.test.js` | OK |
+| Lock/unlock | Builder de test `tx()` | `lock_toggled` | Marque `locked` | Fige `lockedAtPlateauIndex` tant que locked | `jamPipeline.test.js`, `orderResolution.test.js` | OK |
+| Link créé | Builder de test `tx()` | `link_created` | Crée la contrainte link | Aligne / suppress selon conflict/frozen | `jamPipeline.test.js`, `orderResolution.test.js` | OK |
+| Link supprimé | Builder de test `tx()` | `link_removed` | Marque le link removed | Ignore les relations removed | `jamPipeline.test.js` | OK |
+| Conflict créé | Builder de test `tx()` | `conflict_created` | Crée la contrainte conflict | Gagne contre links incompatibles | `jamPipeline.test.js`, `orderResolution.test.js` | OK |
+| Conflict supprimé | Builder de test `tx()` | `conflict_removed` | Marque le conflict removed | Ignore les relations removed | `jamPipeline.test.js` | OK |
+| Skip / call drawer | Builder de test `tx()` | `appearance_skipped` | Marque la décision d’appel | Respecte pins et anchor | `jamPipeline.test.js`, `orderResolution.test.js` | OK |
+| Play without | Builder de test `tx()` | `hole_added` + `link_created` | Ajoute le hole + link | Aligne appearance et hole | `jamPipeline.test.js` | OK |
+| Participant left/removed | Builder de test `tx()` | `participant_left`, `participant_removed` | Marque les cards `left` | Filtre les cards left | `jamPipeline.test.js` | OK |
+| Undo | Builder de test `tx(..., { undone: true })` | Transaction inactive | Pas appliqué par `projectJamState` | Replay actif uniquement | `jamPipeline.test.js` | OK |
+
+## Anciennes logiques supprimées ou conservées
+
+Recherche effectuée dans `frontend/src` :
+
+- `reapplyActiveLinks` : aucune occurrence.
+- `applyLink` : aucune occurrence concurrente.
+- `orderScore` : aucune occurrence.
+- `positionInRound` : aucune occurrence.
+- `roundOrder` : aucune occurrence.
+- `manualRoundOrder` : aucune occurrence.
+- `sortByColumnOrder` : aucune occurrence.
+- `arrayMove` : aucune occurrence.
+- `movedLinkedGroup` : aucune occurrence.
+
+Conclusion : aucune ancienne logique frontend concurrente n’est présente dans ce checkout.
+
+## Tests ajoutés ou modifiés
+
+- `frontend/src/features/jam/jamPipeline.test.js` couvre la pipeline complète local-first avant/après refresh.
+- `frontend/src/features/jam/jamStore.test.js` couvre hydrate serveur + pending locale.
+- `frontend/src/features/projection/orderResolution.test.js` couvre resolver, pins, links/conflicts et replay déterministe.
+
+## Documentation modifiée
+
+- Ajout de ce rapport `docs/action-pipeline-audit.md`.
+
+## Risques restants / prochaines tâches
+
+- Remplacer `localDb.js` par l’adaptateur IndexedDB/Dexie réel quand il sera présent.
+- Brancher les builders UX réels sur les mêmes transactions quand les composants Confiture seront présents.
+- Ajouter des tests React d’interaction utilisateur quand la table UI Confiture existera dans ce checkout.

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -9,6 +9,23 @@ class ResizeObserverMock {
 
 global.ResizeObserver = global.ResizeObserver || ResizeObserverMock;
 
+class WorkerMock {
+  postMessage() {}
+  terminate() {}
+  addEventListener() {}
+  removeEventListener() {}
+}
+
+global.Worker = global.Worker || WorkerMock;
+global.URL.createObjectURL = global.URL.createObjectURL || jest.fn(() => "blob:mock");
+global.URL.revokeObjectURL = global.URL.revokeObjectURL || jest.fn();
+
+HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+  drawImage: jest.fn(),
+  getImageData: jest.fn(() => ({ data: [] })),
+  putImageData: jest.fn(),
+}));
+
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   value: jest.fn().mockImplementation((query) => ({

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "webpack --mode development --watch",
     "build": "webpack --mode production",
-    "test": "jest --runInBand",
+    "test": "node runJest.js",
     "test:watch": "jest --watch",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix"

--- a/frontend/runJest.js
+++ b/frontend/runJest.js
@@ -1,0 +1,10 @@
+const { spawnSync } = require("child_process");
+
+const forwardedArgs = process.argv.slice(2).filter((arg) => arg !== "--run");
+const result = spawnSync(
+  process.platform === "win32" ? "npx.cmd" : "npx",
+  ["jest", "--runInBand", ...forwardedArgs],
+  { stdio: "inherit" }
+);
+
+process.exit(result.status === null ? 1 : result.status);

--- a/frontend/src/components/Reactions/AddReactionModal.test.js
+++ b/frontend/src/components/Reactions/AddReactionModal.test.js
@@ -59,6 +59,6 @@ describe('AddReactionModal', () => {
     fireEvent.click(emojiButton);
     fireEvent.click(await screen.findByRole('button', { name: 'Débloquer' }));
 
-    expect(await screen.findByText('Tu n’as assez de points pour débloquer cet émoji. Les dépôts te font gagner des points.')).toBeInTheDocument();
+    expect(await screen.findByText('Tu n’as pas assez de points pour révéler cet émoji. Les dépôts te font gagner des points.')).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/jam/jamPipeline.test.js
+++ b/frontend/src/features/jam/jamPipeline.test.js
@@ -1,0 +1,159 @@
+const { resetLocalDb } = require("../sync/localDb");
+
+const { applyLocalTransaction, hydrateFromPayload, reloadFromLocalDb } = require("./jamStore");
+
+const tx = (id, events, extra = {}) => ({ id, transactionId: id, events, ...extra });
+const card = (id, columnId = "chant", extra = {}) => ({ id, columnId, round: 0, appearanceIndex: 0, baseOrder: 0, ...extra });
+
+function bootstrap(jamId, cards) {
+  return hydrateFromPayload(jamId, { initialState: { cards }, transactions: [] });
+}
+
+function getCardPlateauIndex(projection, instrumentId, cardId) {
+  const column = projection.columns.find((item) => item.instrument && item.instrument.instrumentId === instrumentId);
+  return column ? column.cards.findIndex((item) => item.id === cardId) : -1;
+}
+
+function expectRefreshStable(jamId, beforeReload) {
+  const afterReload = reloadFromLocalDb(jamId);
+  expect(afterReload.projection.columns).toEqual(beforeReload.projection.columns);
+  return afterReload;
+}
+
+describe("jam full local-first pipeline", () => {
+  beforeEach(() => {
+    resetLocalDb();
+  });
+
+  test("link créé puis refresh conserve le même plateauIndex", () => {
+    const jamId = "pipeline-link";
+    bootstrap(jamId, [
+      card("A", "chant", { appearanceIndex: 0 }),
+      card("B", "chant", { appearanceIndex: 1 }),
+      card("C", "chant", { appearanceIndex: 2 }),
+      card("X", "guitare", { appearanceIndex: 0 }),
+      card("Y", "guitare", { appearanceIndex: 1 }),
+      card("Z", "guitare", { appearanceIndex: 2 }),
+    ]);
+
+    const beforeReload = applyLocalTransaction(jamId, tx("link-B-Z", [{ type: "link_created", payload: { sourceId: "B", targetId: "Z", anchorTarget: "B" } }]));
+
+    expect(getCardPlateauIndex(beforeReload.projection, "chant", "B")).toBe(getCardPlateauIndex(beforeReload.projection, "guitare", "Z"));
+    const afterReload = expectRefreshStable(jamId, beforeReload);
+    expect(getCardPlateauIndex(afterReload.projection, "chant", "B")).toBe(getCardPlateauIndex(afterReload.projection, "guitare", "Z"));
+  });
+
+  test("drag linké puis refresh conserve le follower au même plateauIndex", () => {
+    const jamId = "pipeline-drag-link";
+    bootstrap(jamId, [
+      card("A", "chant", { manualOrder: 0 }),
+      card("B", "chant", { manualOrder: 1 }),
+      card("C", "guitare", { manualOrder: 0 }),
+      card("D", "guitare", { manualOrder: 1 }),
+    ]);
+
+    applyLocalTransaction(jamId, tx("link-A-C", [{ type: "link_created", payload: { sourceId: "A", targetId: "C", anchorTarget: "A" } }]));
+    const beforeReload = applyLocalTransaction(jamId, tx("drag-A", [{ type: "appearance_moved_between", payload: { appearanceId: "A", manualOrder: 10 } }]));
+
+    expect(getCardPlateauIndex(beforeReload.projection, "chant", "A")).toBe(getCardPlateauIndex(beforeReload.projection, "guitare", "C"));
+    expectRefreshStable(jamId, beforeReload);
+  });
+
+  test("played A' puis ajout D puis refresh conserve l’ordre visible", () => {
+    const jamId = "pipeline-played-add";
+    bootstrap(jamId, [
+      card("A", "chant", { round: 0, appearanceIndex: 0 }),
+      card("B", "chant", { round: 0, appearanceIndex: 1 }),
+      card("C", "chant", { round: 0, appearanceIndex: 2 }),
+      card("A'", "chant", { round: 1, appearanceIndex: 0 }),
+      card("B'", "chant", { round: 1, appearanceIndex: 1 }),
+      card("C'", "chant", { round: 1, appearanceIndex: 2 }),
+    ]);
+
+    applyLocalTransaction(jamId, tx("played-prefix", [{ type: "plateau_played", payload: { cardIds: ["A", "B", "C", "A'"] } }]));
+    const beforeReload = applyLocalTransaction(jamId, tx("add-D", [{ type: "participation_added", payload: { appearances: [card("D", "chant", { round: 0, appearanceIndex: 3 }), card("D'", "chant", { round: 1, appearanceIndex: 3 })] } }]));
+
+    expect(beforeReload.projection.columns[0].cards.map((item) => item.id)).toEqual(["A", "B", "C", "A'", "D", "B'", "C'", "D'"]);
+    expectRefreshStable(jamId, beforeReload);
+  });
+
+  test("conflict + drag puis refresh garde l’anchor et la cible mobile", () => {
+    const jamId = "pipeline-conflict-drag";
+    bootstrap(jamId, [card("A", "chant", { manualOrder: 20 }), card("B", "chant", { manualOrder: 10 }), card("C", "chant", { manualOrder: 30 })]);
+
+    applyLocalTransaction(jamId, tx("conflict-A-B", [{ type: "conflict_created", payload: { sourceId: "A", targetId: "B" } }]));
+    const beforeReload = applyLocalTransaction(jamId, tx("drag-A", [{ type: "appearance_moved_between", payload: { appearanceId: "A" } }]));
+
+    expect(beforeReload.projection.columns[0].cards.map((item) => item.id)).toEqual(["A", "B", "C"]);
+    expectRefreshStable(jamId, beforeReload);
+  });
+
+  test("lock + ajout puis refresh ne déplace pas la card locked", () => {
+    const jamId = "pipeline-lock-add";
+    bootstrap(jamId, [
+      card("A", "chant", { round: 0, appearanceIndex: 0 }),
+      card("B", "chant", { round: 0, appearanceIndex: 1 }),
+      card("C", "chant", { round: 0, appearanceIndex: 2 }),
+      card("A'", "chant", { round: 1, appearanceIndex: 0 }),
+      card("B'", "chant", { round: 1, appearanceIndex: 1 }),
+      card("C'", "chant", { round: 1, appearanceIndex: 2 }),
+    ]);
+
+    applyLocalTransaction(jamId, tx("lock-A2", [{ type: "lock_toggled", payload: { appearanceId: "A'", locked: true } }]));
+    const beforeReload = applyLocalTransaction(jamId, tx("add-D", [{ type: "participation_added", payload: { appearances: [card("D", "chant", { round: 0, appearanceIndex: 3 })] } }]));
+
+    expect(getCardPlateauIndex(beforeReload.projection, "chant", "A'")).toBe(3);
+    expectRefreshStable(jamId, beforeReload);
+  });
+
+  test("play without puis refresh aligne l’apparence et le hole", () => {
+    const jamId = "pipeline-without";
+    bootstrap(jamId, [
+      card("A", "chant", { manualOrder: 1 }),
+      card("B", "chant", { manualOrder: 0 }),
+      card("X", "guitare", { manualOrder: 0 }),
+      card("Y", "guitare", { manualOrder: 1 }),
+    ]);
+
+    const beforeReload = applyLocalTransaction(jamId, tx("without-A", [
+      { type: "hole_added", payload: { holeId: "A-hole", columnId: "guitare", manualOrder: 10 } },
+      { type: "link_created", payload: { sourceId: "A", targetId: "A-hole", anchorTarget: "A" } },
+    ]));
+
+    expect(getCardPlateauIndex(beforeReload.projection, "chant", "A")).toBe(getCardPlateauIndex(beforeReload.projection, "guitare", "A-hole"));
+    expectRefreshStable(jamId, beforeReload);
+  });
+
+  test("undo puis refresh retire le link et conserve un ordre déterministe", () => {
+    const jamId = "pipeline-undo";
+    bootstrap(jamId, [card("A", "chant", { manualOrder: 0 }), card("B", "chant", { manualOrder: 1 })]);
+
+    applyLocalTransaction(jamId, tx("link-A-B", [{ type: "link_created", payload: { sourceId: "A", targetId: "B", anchorTarget: "A" } }]));
+    const beforeReload = applyLocalTransaction(jamId, tx("link-A-B", [{ type: "link_created", payload: { sourceId: "A", targetId: "B", anchorTarget: "A" } }], { undone: true }));
+
+    expect(beforeReload.projection.links || []).toEqual([]);
+    expect(beforeReload.projection.columns[0].cards.map((item) => item.id)).toEqual(["A", "B"]);
+    expectRefreshStable(jamId, beforeReload);
+  });
+
+  test("actions de structure diverses restent stables après refresh", () => {
+    const jamId = "pipeline-misc-actions";
+    bootstrap(jamId, [card("A", "chant", { participantId: "p1" }), card("B", "chant")]);
+
+    const beforeReload = applyLocalTransaction(jamId, tx("misc", [
+      { type: "participant_updated", payload: { participantId: "p1", name: "Anne" } },
+      { type: "round_revealed", payload: { round: 1 } },
+      { type: "appearance_skipped", payload: { appearanceId: "B" } },
+      { type: "link_created", payload: { sourceId: "A", targetId: "B", anchorTarget: "A" } },
+      { type: "link_removed", payload: { sourceId: "A", targetId: "B" } },
+      { type: "conflict_created", payload: { sourceId: "A", targetId: "B" } },
+      { type: "conflict_removed", payload: { sourceId: "A", targetId: "B" } },
+      { type: "participant_left", payload: { participantId: "p1" } },
+    ]));
+
+    expect(beforeReload.projection.participants).toEqual([{ id: "p1", participantId: "p1", name: "Anne" }]);
+    expect(beforeReload.projection.cards.find((item) => item.id === "A")).toBeUndefined();
+    expect(beforeReload.projection.cards.find((item) => item.id === "B")).toMatchObject({ appearanceSkipped: true });
+    expectRefreshStable(jamId, beforeReload);
+  });
+});

--- a/frontend/src/features/jam/jamStore.js
+++ b/frontend/src/features/jam/jamStore.js
@@ -1,0 +1,29 @@
+const { projectJamState } = require("../projection/projectJamState");
+const { addPendingTransaction, getBaseState, getMergedTransactions, getPendingTransactions, persistServerPayload } = require("../sync/localDb");
+
+function reloadFromLocalDb(jamId) {
+  const transactions = getMergedTransactions(jamId);
+  const projection = projectJamState(getBaseState(jamId), transactions);
+  return {
+    jamId,
+    projection,
+    pendingTransactions: getPendingTransactions(jamId),
+    transactions,
+  };
+}
+
+function hydrateFromPayload(jamId, payload) {
+  persistServerPayload(jamId, payload);
+  return reloadFromLocalDb(jamId);
+}
+
+function applyLocalTransaction(jamId, transaction) {
+  addPendingTransaction(jamId, transaction);
+  return reloadFromLocalDb(jamId);
+}
+
+module.exports = {
+  applyLocalTransaction,
+  hydrateFromPayload,
+  reloadFromLocalDb,
+};

--- a/frontend/src/features/jam/jamStore.test.js
+++ b/frontend/src/features/jam/jamStore.test.js
@@ -1,0 +1,75 @@
+const { addPendingTransaction, getPendingTransactions, resetLocalDb } = require("../sync/localDb");
+
+const { hydrateFromPayload } = require("./jamStore");
+
+const cardIds = (state) => state.projection.cards.map((card) => card.id);
+const tx = (id, events, extra = {}) => ({ id, transactionId: id, events, ...extra });
+const addCard = (id, extra = {}) => ({ type: "participation_added", payload: { appearances: [{ id, round: 0, appearanceIndex: extra.appearanceIndex ?? 0, ...extra }] } });
+
+describe("jamStore local-first hydration", () => {
+  beforeEach(() => {
+    resetLocalDb();
+  });
+
+  test("hydrate serveur conserve une transaction locale pending absente du payload", () => {
+    addPendingTransaction("jam-1", tx("A", [addCard("A")], { localSequence: 1 }));
+
+    const hydrated = hydrateFromPayload("jam-1", { initialState: { cards: [] }, transactions: [] });
+
+    expect(cardIds(hydrated)).toEqual(["A"]);
+    expect(getPendingTransactions("jam-1").map((transaction) => transaction.id)).toEqual(["A"]);
+  });
+
+  test("hydrate serveur ack une pending sans dupliquer la projection", () => {
+    addPendingTransaction("jam-1", tx("A", [addCard("A")], { localSequence: 1 }));
+
+    const hydrated = hydrateFromPayload("jam-1", {
+      initialState: { cards: [] },
+      transactions: [tx("A", [addCard("A")], { serverSequenceNumberStart: 1 })],
+    });
+
+    expect(cardIds(hydrated)).toEqual(["A"]);
+    expect(hydrated.transactions).toHaveLength(1);
+    expect(hydrated.transactions[0]).toMatchObject({ id: "A", syncStatus: "synced", serverSequenceNumberStart: 1 });
+    expect(getPendingTransactions("jam-1")).toEqual([]);
+  });
+
+  test("ordre déterministe avec transactions serveur puis pending après refresh", () => {
+    const payload = {
+      initialState: { cards: [] },
+      transactions: [
+        tx("A", [addCard("A", { appearanceIndex: 0 })], { serverSequenceNumberStart: 1 }),
+        tx("B", [addCard("B", { appearanceIndex: 1 })], { serverSequenceNumberStart: 2 }),
+      ],
+    };
+    addPendingTransaction("jam-1", tx("C", [addCard("C", { appearanceIndex: 2 })], { localSequence: 1 }));
+
+    const first = hydrateFromPayload("jam-1", payload);
+    const second = hydrateFromPayload("jam-1", payload);
+
+    expect(cardIds(first)).toEqual(["A", "B", "C"]);
+    expect(cardIds(second)).toEqual(["A", "B", "C"]);
+    expect(second.projection.columns[0].cards.map((card) => card.id)).toEqual(["A", "B", "C"]);
+  });
+
+  test("hydrate applique toujours le resolver avec serveur et pending locale", () => {
+    const payload = {
+      initialState: { cards: [] },
+      transactions: [
+        tx("seed", [
+          addCard("A", { appearanceIndex: 0 }),
+          addCard("B", { appearanceIndex: 1 }),
+        ], { serverSequenceNumberStart: 1 }),
+        tx("link", [{ type: "link_created", payload: { sourceId: "A", targetId: "B", anchorTarget: "A" } }], { serverSequenceNumberStart: 2 }),
+        tx("played", [{ type: "plateau_played", payload: { cardIds: ["A"] } }], { serverSequenceNumberStart: 3 }),
+      ],
+    };
+    addPendingTransaction("jam-1", tx("pending-C", [addCard("C", { appearanceIndex: 2 })], { localSequence: 1 }));
+
+    const hydrated = hydrateFromPayload("jam-1", payload);
+
+    expect(cardIds(hydrated)).toEqual(["A", "B", "C"]);
+    expect(hydrated.projection.cards[0]).toMatchObject({ id: "A", played: true, playedAtPlateauIndex: 0 });
+    expect(hydrated.projection.orderWarnings).toEqual([]);
+  });
+});

--- a/frontend/src/features/projection/applyEvent.js
+++ b/frontend/src/features/projection/applyEvent.js
@@ -1,0 +1,233 @@
+function eventPayload(event) {
+  return event && event.payload ? event.payload : {};
+}
+
+function eventTargetId(payload) {
+  return payload.cardId || payload.appearanceId || payload.targetId || payload.id;
+}
+
+function upsertById(items, nextItem) {
+  const list = Array.isArray(items) ? items : [];
+  const id = nextItem && nextItem.id;
+  if (!id) {return list;}
+  const index = list.findIndex((item) => item && item.id === id);
+  if (index === -1) {return [...list, nextItem];}
+  return list.map((item, itemIndex) => itemIndex === index ? { ...item, ...nextItem } : item);
+}
+
+function updateCards(state, predicate, updater) {
+  const cards = Array.isArray(state && state.cards) ? state.cards : [];
+  return {
+    ...state,
+    cards: cards.map((card) => predicate(card) ? updater(card) : card),
+  };
+}
+
+function applyParticipantUpdated(state, payload) {
+  const id = payload.participantId || payload.id;
+  if (!id) {return state;}
+  return {
+    ...state,
+    participants: upsertById(state.participants, { id, ...payload }),
+  };
+}
+
+function applyLinkCreated(state, payload) {
+  const sourceId = payload.sourceId || payload.fromId || payload.cardId || payload.appearanceId;
+  const targetId = payload.targetId || payload.toId || payload.linkedCardId;
+  if (!sourceId || !targetId) {return state;}
+  const link = {
+    id: payload.id || `${sourceId}:${targetId}`,
+    sourceId,
+    targetId,
+    anchorTarget: payload.anchorTarget,
+    anchorTargetId: payload.anchorTargetId,
+    strategy: payload.strategy,
+    status: payload.status || "active",
+  };
+  return { ...state, links: upsertById(state.links, link) };
+}
+
+function applyLinkRemoved(state, payload) {
+  const sourceId = payload.sourceId || payload.fromId || payload.cardId || payload.appearanceId;
+  const targetId = payload.targetId || payload.toId || payload.linkedCardId;
+  const links = Array.isArray(state && state.links) ? state.links : [];
+  return {
+    ...state,
+    links: links.map((link) => (
+      (link.id && link.id === payload.id) ||
+      (sourceId && targetId && link.sourceId === sourceId && link.targetId === targetId)
+        ? { ...link, status: "removed" }
+        : link
+    )),
+  };
+}
+
+function applyConflictCreated(state, payload) {
+  const sourceId = payload.sourceId || payload.fromId || payload.cardId || payload.appearanceId;
+  const targetId = payload.targetId || payload.toId || payload.conflictCardId;
+  if (!sourceId || !targetId) {return state;}
+  const conflict = {
+    id: payload.id || `${sourceId}:${targetId}`,
+    sourceId,
+    targetId,
+    anchorTargetId: payload.anchorTargetId,
+    status: payload.status || "active",
+  };
+  return { ...state, conflicts: upsertById(state.conflicts, conflict) };
+}
+
+function applyConflictRemoved(state, payload) {
+  const sourceId = payload.sourceId || payload.fromId || payload.cardId || payload.appearanceId;
+  const targetId = payload.targetId || payload.toId || payload.conflictCardId;
+  const conflicts = Array.isArray(state && state.conflicts) ? state.conflicts : [];
+  return {
+    ...state,
+    conflicts: conflicts.map((conflict) => (
+      (conflict.id && conflict.id === payload.id) ||
+      (sourceId && targetId && conflict.sourceId === sourceId && conflict.targetId === targetId)
+        ? { ...conflict, status: "removed" }
+        : conflict
+    )),
+  };
+}
+
+function applyAppearanceMovedBetween(state, payload) {
+  const targetId = eventTargetId(payload);
+  if (!targetId) {return state;}
+  return updateCards(
+    state,
+    (card) => [card.id, card.cardId, card.appearanceId].includes(targetId),
+    (card) => ({
+      ...card,
+      manualOrder: payload.manualOrder ?? payload.manualOrderKey ?? card.manualOrder,
+      manualOrderIntent: {
+        targetId,
+        beforeTargetId: payload.beforeTargetId,
+        afterTargetId: payload.afterTargetId,
+        anchorTargetId: targetId,
+      },
+    })
+  );
+}
+
+function applyPlateauPlayed(state, payload) {
+  const targetIds = new Set([...(payload.cardIds || []), ...(payload.appearanceIds || []), eventTargetId(payload)].filter(Boolean));
+  if (!targetIds.size) {return state;}
+  return updateCards(
+    state,
+    (card) => targetIds.has(card.id) || targetIds.has(card.cardId) || targetIds.has(card.appearanceId),
+    (card) => ({ ...card, played: true, playedAtTransactionId: payload.transactionId || card.playedAtTransactionId })
+  );
+}
+
+function applyLockToggled(state, payload) {
+  const targetId = eventTargetId(payload);
+  if (!targetId) {return state;}
+  return updateCards(
+    state,
+    (card) => [card.id, card.cardId, card.appearanceId].includes(targetId),
+    (card) => ({ ...card, locked: payload.locked !== undefined ? Boolean(payload.locked) : !card.locked })
+  );
+}
+
+function applyRoundRevealed(state, payload) {
+  const round = payload.round ?? payload.roundIndex;
+  if (round === undefined || round === null) {return state;}
+  return { ...state, revealedRounds: [...new Set([...(state.revealedRounds || []), round])].sort((a, b) => a - b) };
+}
+
+function applyParticipationAdded(state, payload) {
+  const cards = Array.isArray(state && state.cards) ? state.cards : [];
+  const appearances = payload.appearances || payload.cards || (payload.newAppearanceIds || payload.appearanceIds || []).map((id, index) => ({
+    id,
+    round: payload.round ?? 0,
+    appearanceIndex: payload.appearanceIndex ?? cards.length + index,
+  }));
+  return {
+    ...state,
+    cards: [...cards, ...appearances],
+  };
+}
+
+function applyHoleAdded(state, payload) {
+  const holeId = payload.holeId || payload.id;
+  if (!holeId) {return state;}
+  const hole = {
+    id: holeId,
+    columnId: payload.columnId || payload.instrumentId || payload.column,
+    round: payload.round ?? 0,
+    appearanceIndex: payload.appearanceIndex,
+    manualOrder: payload.manualOrder,
+    isHole: true,
+  };
+  return {
+    ...state,
+    cards: [...(Array.isArray(state && state.cards) ? state.cards : []), hole],
+  };
+}
+
+function applyParticipantLeft(state, payload) {
+  const participantId = payload.participantId || payload.id;
+  if (!participantId) {return state;}
+  return updateCards(
+    state,
+    (card) => card.participantId === participantId,
+    (card) => ({ ...card, status: "left", left: true })
+  );
+}
+
+function applyAppearanceSkipped(state, payload) {
+  const targetId = eventTargetId(payload);
+  if (!targetId) {return state;}
+  return updateCards(
+    state,
+    (card) => [card.id, card.cardId, card.appearanceId].includes(targetId),
+    (card) => ({ ...card, appearanceSkipped: true, callDecision: "skipped" })
+  );
+}
+
+function applyEvent(state, event) {
+  const payload = eventPayload(event);
+  switch (event && event.type) {
+    case "participant_updated":
+      return applyParticipantUpdated(state, payload);
+    case "link_created":
+      return applyLinkCreated(state, payload);
+    case "link_removed":
+      return applyLinkRemoved(state, payload);
+    case "conflict_created":
+      return applyConflictCreated(state, payload);
+    case "conflict_removed":
+      return applyConflictRemoved(state, payload);
+    case "appearance_moved_between":
+      return applyAppearanceMovedBetween(state, payload);
+    case "plateau_played":
+      return applyPlateauPlayed(state, payload);
+    case "lock_toggled":
+      return applyLockToggled(state, payload);
+    case "round_revealed":
+      return applyRoundRevealed(state, payload);
+    case "participation_added":
+      return applyParticipationAdded(state, payload);
+    case "hole_added":
+      return applyHoleAdded(state, payload);
+    case "appearance_skipped":
+      return applyAppearanceSkipped(state, payload);
+    case "participant_left":
+    case "participant_removed":
+      return applyParticipantLeft(state, payload);
+    default:
+      return state;
+  }
+}
+
+function applyTransaction(state, transaction) {
+  const events = Array.isArray(transaction && transaction.events) ? transaction.events : [];
+  return events.reduce((current, event) => applyEvent(current, event), state);
+}
+
+module.exports = {
+  applyEvent,
+  applyTransaction,
+};

--- a/frontend/src/features/projection/orderResolution.js
+++ b/frontend/src/features/projection/orderResolution.js
@@ -12,6 +12,11 @@ function cardId(card) {
   return stableId(card && (card.id || card.cardId || card.appearanceId));
 }
 
+function cardTarget(card) {
+  const id = cardId(card);
+  return id ? { type: "card", id } : null;
+}
+
 function columnId(card) {
   return stableId(card && (card.columnId || card.column || "default"));
 }
@@ -20,12 +25,28 @@ function isRemoved(card) {
   return Boolean(card && (card.removed || card.left || card.hidden || REMOVED_STATUSES.has(card.status)));
 }
 
+function isCardActive(card) {
+  return Boolean(card) && !isRemoved(card);
+}
+
 function isPlayed(card) {
   return Boolean(card && (card.played || card.playedAt || PLAYED_STATUSES.has(card.status)));
 }
 
+function isCardPlayed(card) {
+  return isPlayed(card);
+}
+
 function isLocked(card) {
   return Boolean(card && (card.locked || card.lockedAt || LOCKED_STATUSES.has(card.status)));
+}
+
+function isCardLocked(card) {
+  return isLocked(card);
+}
+
+function getInstrumentIdForCard(card) {
+  return columnId(card);
 }
 
 function numberOrInfinity(value) {
@@ -34,14 +55,15 @@ function numberOrInfinity(value) {
 
 function frozenOrderKey(card) {
   if (isPlayed(card)) {return numberOrInfinity(card.playedAtPlateauIndex ?? card.frozenOrderKey ?? card.__fallbackIndex);}
-  if (isLocked(card)) {return numberOrInfinity(card.lockedOrderKey ?? card.frozenOrderKey ?? card.__fallbackIndex);}
+  if (isLocked(card)) {return numberOrInfinity(card.lockedAtPlateauIndex ?? card.lockedOrderKey ?? card.frozenOrderKey ?? card.__fallbackIndex);}
   return Infinity;
 }
 
 function withCapturedFrozenOrder(card, fallbackIndex) {
   const next = { ...card, __fallbackIndex: fallbackIndex };
   if (isPlayed(next) && (next.playedAtPlateauIndex === null || next.playedAtPlateauIndex === undefined)) {next.playedAtPlateauIndex = fallbackIndex;}
-  if (isLocked(next) && (next.lockedOrderKey === null || next.lockedOrderKey === undefined)) {next.lockedOrderKey = fallbackIndex;}
+  if (isLocked(next) && (next.lockedAtPlateauIndex === null || next.lockedAtPlateauIndex === undefined)) {next.lockedAtPlateauIndex = next.lockedOrderKey ?? fallbackIndex;}
+  if (isLocked(next) && (next.lockedOrderKey === null || next.lockedOrderKey === undefined)) {next.lockedOrderKey = next.lockedAtPlateauIndex ?? fallbackIndex;}
   if ((next.frozenOrderKey === null || next.frozenOrderKey === undefined) && (isPlayed(next) || isLocked(next))) {next.frozenOrderKey = fallbackIndex;}
   return next;
 }
@@ -81,8 +103,8 @@ function compareKeys(left, right) {
 function collectActiveCardsByColumn(state) {
   const cards = Array.isArray(state && state.cards) ? state.cards : [];
   return cards.reduce((columns, card, fallbackIndex) => {
-    if (isRemoved(card)) {return columns;}
-    const key = columnId(card);
+    if (!isCardActive(card)) {return columns;}
+    const key = getInstrumentIdForCard(card);
     if (!columns[key]) {columns[key] = [];}
     columns[key].push(withCapturedFrozenOrder(card, fallbackIndex));
     return columns;
@@ -93,6 +115,28 @@ function collectActiveCardsByColumn(state) {
 function targetKey(target) {
   if (typeof target === "string" || typeof target === "number") {return stableId(target);}
   return stableId(target && (target.cardId || target.appearanceId || target.id || target.targetId));
+}
+
+function sortCardsByCurrentResolvedOrder(cards) {
+  return [...(Array.isArray(cards) ? cards : [])].sort((a, b) =>
+    compareKeys([
+      numberOrInfinity(a && a.resolvedColumnOrder),
+      numberOrInfinity(a && a.resolvedOrder),
+      numberOrInfinity(a && a.resolvedPlateauIndex),
+      ...basePosition(a || {}, a && a.__fallbackIndex),
+      cardId(a),
+    ], [
+      numberOrInfinity(b && b.resolvedColumnOrder),
+      numberOrInfinity(b && b.resolvedOrder),
+      numberOrInfinity(b && b.resolvedPlateauIndex),
+      ...basePosition(b || {}, b && b.__fallbackIndex),
+      cardId(b),
+    ])
+  );
+}
+
+function getCardsByInstrument(state) {
+  return collectActiveCardsByColumn(state);
 }
 
 function getVisibleColumns(state) {
@@ -156,6 +200,7 @@ const EVENT_ANCHOR_READERS = {
   conflict_created: (payload) => payloadValues(payload, ["anchorTargetId", "anchorTarget", "targetId"]),
   participation_added: (payload) => payloadValues(payload, ["newAppearanceIds", "appearanceIds", "cardIds"]).slice(0, 1),
   hole_added: (payload) => payloadValues(payload, ["holeId", "cardId", "appearanceId", "id"]),
+  hole_moved: (payload) => payloadValues(payload, ["holeId", "cardId", "appearanceId", "id"]),
   appearance_skipped: (payload) => payloadValues(payload, ["cardId", "appearanceId", "id"]),
   appearance_replaced: (payload) => payloadValues(payload, ["replacementAppearanceId", "appearanceId", "cardId", "targetAppearanceId", "id"]),
   replacement_selected: (payload) => payloadValues(payload, ["replacementAppearanceId", "appearanceId", "cardId", "targetAppearanceId", "id"]),
@@ -168,7 +213,7 @@ function eventAnchors(event) {
   const payload = event.payload || event;
   if (MANUAL_REORDER_EVENT_TYPES.has(event.type)) {return payloadValues({ anchor: manualReorderAnchor(payload) }, ["anchor"]);}
   const reader = EVENT_ANCHOR_READERS[event.type];
-  return reader ? reader(payload) : [];
+  return reader ? reader(payload).map((target) => targetKey(target)) : [];
 }
 
 function identifyAnchors(context) {
@@ -177,7 +222,9 @@ function identifyAnchors(context) {
 }
 
 function relationPairs(state, key) {
-  return (Array.isArray(state && state[key]) ? state[key] : []).map((relation) => [
+  return (Array.isArray(state && state[key]) ? state[key] : []).filter((relation) =>
+    relation && relation.status !== "removed" && relation.status !== "deleted" && relation.status !== "inactive" && relation.active !== false
+  ).map((relation) => [
     stableId(relation.sourceId || relation.fromId || relation.a || relation.leftId || relation.cardId),
     stableId(relation.targetId || relation.toId || relation.b || relation.rightId || relation.linkedCardId || relation.conflictCardId),
   ]).filter(([a, b]) => a && b && a !== b);
@@ -219,6 +266,37 @@ function moveCardToPlateauIndex(cards, id, targetIndex) {
   const boundedIndex = Math.max(0, Math.min(targetIndex, next.length));
   next.splice(boundedIndex, 0, card);
   return next;
+}
+
+function applyFrozenSlots(cards) {
+  const frozenCards = cards
+    .filter((card) => isPlayed(card) || isLocked(card))
+    .sort((a, b) => compareKeys([frozenOrderKey(a), cardId(a)], [frozenOrderKey(b), cardId(b)]));
+  if (!frozenCards.length) {return cards;}
+
+  const frozenIds = new Set(frozenCards.map(cardId));
+  const mobileCards = cards.filter((card) => !frozenIds.has(cardId(card)));
+  const next = new Array(cards.length);
+
+  frozenCards.forEach((card) => {
+    const preferredIndex = Math.max(0, Math.min(numberOrInfinity(frozenOrderKey(card)), cards.length - 1));
+    let index = preferredIndex;
+    while (index < next.length && next[index]) {index += 1;}
+    if (index >= next.length) {
+      index = preferredIndex;
+      while (index >= 0 && next[index]) {index -= 1;}
+    }
+    next[index] = card;
+  });
+
+  let mobileIndex = 0;
+  for (let index = 0; index < next.length; index += 1) {
+    if (!next[index]) {
+      next[index] = mobileCards[mobileIndex];
+      mobileIndex += 1;
+    }
+  }
+  return next.filter(Boolean);
 }
 
 function suppressLinks(state, suppressedKeys) {
@@ -391,22 +469,35 @@ function resolveOrderAfterTransaction(state, context = {}) {
       const blockingFrozenKeys = sortedMembers.some((card) => isPlayed(card) || isLocked(card)) || minManual === Infinity
         ? []
         : cards.map(frozenOrderKey).filter((key) => key !== Infinity && minManual < key && shouldRespectFrozenBoundary(key));
-      const effectiveManual = blockingFrozenKeys.length ? Math.max(minManual, Math.max(...blockingFrozenKeys) + 0.1) : minManual;
-      return { members: sortedMembers, key: [hasPlayed || hasLocked ? minFrozen : effectiveManual, hasPlayed ? 0 : hasLocked ? 1 : 2, hasAnchor ? 0 : 1, hasDecision ? 0 : 1, minManual, ...minBase] };
+      const hasBlockedFrozenBoundary = blockingFrozenKeys.length > 0;
+      const effectiveManual = blockingFrozenKeys.length ? Infinity : minManual;
+      const hasAnchorPriority = hasAnchor && minManual !== Infinity && !hasBlockedFrozenBoundary;
+      return { members: sortedMembers, key: [hasPlayed || hasLocked ? minFrozen : effectiveManual, hasPlayed ? 0 : hasLocked ? 1 : 2, hasAnchorPriority ? 0 : 1, hasDecision ? 0 : 1, hasBlockedFrozenBoundary ? Infinity : minManual, ...minBase] };
     });
 
-    resolvedColumns[col] = units.sort((a, b) => compareKeys(a.key, b.key) || cardId(a.members[0]).localeCompare(cardId(b.members[0]))).flatMap((unit) => unit.members);
+    resolvedColumns[col] = applyFrozenSlots(units.sort((a, b) => compareKeys(a.key, b.key) || cardId(a.members[0]).localeCompare(cardId(b.members[0]))).flatMap((unit) => unit.members));
   });
 
   const linkResolution = resolveActiveLinksInColumns(state, resolvedColumns, warnings);
   const finalColumns = linkResolution.columns;
 
-  const resolvedCards = Object.values(finalColumns).flatMap((cards) => cards).map((card, index) => {
-    const next = { ...card, resolvedOrder: index };
+  // Derived order fields are projection-only and fully replayable from the event log:
+  // - resolvedPlateauIndex: visible row within the instrument/column.
+  // - resolvedColumnOrder: stable flattened display order used by column builders.
+  // - playedAtPlateauIndex / lockedAtPlateauIndex / frozenOrderKey: frozen pins for cards
+  //   that must not move while they remain played or locked.
+  const resolvedCards = Object.values(finalColumns).flatMap((cards) => cards.map((card, plateauIndex) => ({ card, plateauIndex }))).map(({ card, plateauIndex }, columnOrder) => {
+    const next = {
+      ...card,
+      resolvedOrder: columnOrder,
+      resolvedColumnOrder: columnOrder,
+      resolvedPlateauIndex: plateauIndex,
+    };
     delete next.__fallbackIndex;
-    if (isPlayed(next) && (next.playedAtPlateauIndex === null || next.playedAtPlateauIndex === undefined)) {next.playedAtPlateauIndex = index;}
-    if (isLocked(next) && (next.lockedOrderKey === null || next.lockedOrderKey === undefined)) {next.lockedOrderKey = index;}
-    if ((next.frozenOrderKey === null || next.frozenOrderKey === undefined) && (isPlayed(next) || isLocked(next))) {next.frozenOrderKey = frozenOrderKey(next) === Infinity ? index : frozenOrderKey(next);}
+    if (isPlayed(next) && (next.playedAtPlateauIndex === null || next.playedAtPlateauIndex === undefined)) {next.playedAtPlateauIndex = plateauIndex;}
+    if (isLocked(next) && (next.lockedAtPlateauIndex === null || next.lockedAtPlateauIndex === undefined)) {next.lockedAtPlateauIndex = plateauIndex;}
+    if (isLocked(next) && (next.lockedOrderKey === null || next.lockedOrderKey === undefined)) {next.lockedOrderKey = next.lockedAtPlateauIndex;}
+    if ((next.frozenOrderKey === null || next.frozenOrderKey === undefined) && (isPlayed(next) || isLocked(next))) {next.frozenOrderKey = frozenOrderKey(next) === Infinity ? plateauIndex : frozenOrderKey(next);}
     return next;
   });
 
@@ -456,4 +547,11 @@ module.exports = {
   identifyAnchors,
   isPlayed,
   isLocked,
+  cardTarget,
+  isCardActive,
+  isCardPlayed,
+  isCardLocked,
+  getInstrumentIdForCard,
+  getCardsByInstrument,
+  sortCardsByCurrentResolvedOrder,
 };

--- a/frontend/src/features/projection/orderResolution.test.js
+++ b/frontend/src/features/projection/orderResolution.test.js
@@ -1,9 +1,229 @@
-const { resolveOrderAfterTransaction, applyTransactionAndResolve, projectEventLog } = require('./orderResolution');
+const { applyEvent, applyTransaction } = require('./applyEvent');
+const {
+  resolveOrderAfterTransaction,
+  applyTransactionAndResolve,
+  projectEventLog,
+  cardTarget,
+  getCardsByInstrument,
+  getInstrumentIdForCard,
+  identifyAnchors,
+  isCardActive,
+  isCardLocked,
+  isCardPlayed,
+  sortCardsByCurrentResolvedOrder,
+  targetKey,
+} = require('./orderResolution');
+const { projectJamState } = require('./projectJamState');
 
 const ids = (state) => state.cards.map((card) => card.id);
 const c = (id, extra = {}) => ({ id, round: 0, appearanceIndex: 0, baseOrder: 0, ...extra });
 
 describe('orderResolution', () => {
+  test("ajout après des cards jouées du round 2 conserve le préfixe frozen", () => {
+    const initial = { cards: [
+      c('A', { round: 0, appearanceIndex: 0 }),
+      c('B', { round: 0, appearanceIndex: 1 }),
+      c('C', { round: 0, appearanceIndex: 2 }),
+      c("A'", { round: 1, appearanceIndex: 0 }),
+      c("B'", { round: 1, appearanceIndex: 1 }),
+      c("C'", { round: 1, appearanceIndex: 2 }),
+    ] };
+    const eventLog = [
+      { events: [{ type: 'plateau_played', payload: { cardIds: ['A', 'B', 'C', "A'"] } }] },
+      { events: [{ type: 'participation_added', payload: { newAppearanceIds: ['D', "D'"] } }] },
+    ];
+    const apply = (state, event) => {
+      if (event.type === 'plateau_played') {
+        return { ...state, cards: state.cards.map((card) => event.payload.cardIds.includes(card.id) ? { ...card, played: true } : card) };
+      }
+      if (event.type === 'participation_added') {
+        return { ...state, cards: [...state.cards, c('D', { round: 0, appearanceIndex: 3 }), c("D'", { round: 1, appearanceIndex: 3 })] };
+      }
+      return state;
+    };
+
+    const projected = projectEventLog(initial, eventLog, apply);
+
+    expect(ids(projected)).toEqual(['A', 'B', 'C', "A'", 'D', "B'", "C'", "D'"]);
+    expect(projected.cards.slice(0, 4).map((card) => card.playedAtPlateauIndex)).toEqual([0, 1, 2, 3]);
+    expect(projected.cards.slice(0, 4).map((card) => card.resolvedPlateauIndex)).toEqual([0, 1, 2, 3]);
+  });
+
+  test("ajout autour d’une card locked ne décale pas A'", () => {
+    const state = { cards: [
+      c('A', { round: 0, appearanceIndex: 0 }),
+      c('B', { round: 0, appearanceIndex: 1 }),
+      c('C', { round: 0, appearanceIndex: 2 }),
+      c("A'", { round: 1, appearanceIndex: 0, locked: true, lockedAtPlateauIndex: 3 }),
+      c("B'", { round: 1, appearanceIndex: 1 }),
+      c("C'", { round: 1, appearanceIndex: 2 }),
+      c('D', { round: 0, appearanceIndex: 3 }),
+    ] };
+
+    const resolved = resolveOrderAfterTransaction(state, { events: [{ type: 'participation_added', payload: { newAppearanceIds: ['D'] } }] });
+
+    expect(resolved.cards.find((card) => card.id === "A'").resolvedPlateauIndex).toBe(3);
+    expect(ids(resolved).indexOf('D')).toBeGreaterThan(ids(resolved).indexOf("A'"));
+  });
+
+  test("played ne bouge pas lors d’un drag autour de A'", () => {
+    const state = { cards: [
+      c('A', { round: 0, appearanceIndex: 0 }),
+      c('B', { round: 0, appearanceIndex: 1 }),
+      c('C', { round: 0, appearanceIndex: 2 }),
+      c("A'", { round: 1, appearanceIndex: 0, played: true, playedAtPlateauIndex: 3 }),
+      c("B'", { round: 1, appearanceIndex: 1, manualOrder: -1 }),
+    ] };
+
+    const resolved = resolveOrderAfterTransaction(state, { events: [{ type: 'appearance_moved_between', payload: { appearanceId: "B'", beforeTargetId: "A'" } }] });
+
+    expect(resolved.cards.find((card) => card.id === "A'").resolvedPlateauIndex).toBe(3);
+  });
+
+  test("locked ne bouge pas lors d’un drag autour de A'", () => {
+    const state = { cards: [
+      c('A', { round: 0, appearanceIndex: 0 }),
+      c('B', { round: 0, appearanceIndex: 1 }),
+      c('C', { round: 0, appearanceIndex: 2 }),
+      c("A'", { round: 1, appearanceIndex: 0, locked: true, lockedAtPlateauIndex: 3 }),
+      c("B'", { round: 1, appearanceIndex: 1, manualOrder: -1 }),
+    ] };
+
+    const resolved = resolveOrderAfterTransaction(state, { events: [{ type: 'appearance_moved_between', payload: { appearanceId: "B'", beforeTargetId: "A'" } }] });
+
+    expect(resolved.cards.find((card) => card.id === "A'").resolvedPlateauIndex).toBe(3);
+  });
+
+  test('replay déterministe avec reveal, played, ajout, lock et drag', () => {
+    const initial = { cards: [
+      c('A', { round: 0, appearanceIndex: 0 }),
+      c('B', { round: 0, appearanceIndex: 1 }),
+      c("A'", { round: 1, appearanceIndex: 0 }),
+    ] };
+    const eventLog = [
+      { events: [{ type: 'round_revealed', payload: { round: 1 } }] },
+      { events: [{ type: 'plateau_played', payload: { cardIds: ['A'] } }] },
+      { events: [{ type: 'participation_added', payload: { newAppearanceIds: ['D'] } }] },
+      { events: [{ type: 'lock_toggled', payload: { appearanceId: "A'", locked: true } }] },
+      { events: [{ type: 'appearance_moved_between', payload: { appearanceId: 'D', manualOrder: -1 } }] },
+    ];
+    const apply = (state, event) => {
+      if (event.type === 'plateau_played') {
+        return { ...state, cards: state.cards.map((card) => event.payload.cardIds.includes(card.id) ? { ...card, played: true } : card) };
+      }
+      if (event.type === 'participation_added') {
+        return { ...state, cards: [...state.cards, c('D', { round: 0, appearanceIndex: 2 })] };
+      }
+      if (event.type === 'lock_toggled') {
+        return { ...state, cards: state.cards.map((card) => card.id === event.payload.appearanceId ? { ...card, locked: event.payload.locked } : card) };
+      }
+      if (event.type === 'appearance_moved_between') {
+        return { ...state, cards: state.cards.map((card) => card.id === event.payload.appearanceId ? { ...card, manualOrder: event.payload.manualOrder } : card) };
+      }
+      return state;
+    };
+
+    expect(projectEventLog(initial, eventLog, apply)).toEqual(projectEventLog(initial, eventLog, apply));
+  });
+
+  test('participant_updated reste un fait métier et ne change pas l’ordre', () => {
+    const state = { cards: [c('A', { resolvedOrder: 0 }), c('B', { resolvedOrder: 1 })], participants: [{ id: 'p1', name: 'Ana' }] };
+
+    const next = applyEvent(state, { type: 'participant_updated', payload: { participantId: 'p1', name: 'Anne' } });
+
+    expect(ids(next)).toEqual(['A', 'B']);
+    expect(next.participants).toEqual([{ id: 'p1', participantId: 'p1', name: 'Anne' }]);
+  });
+
+  test('link_created crée une contrainte et laisse l’ordre final au resolver', () => {
+    const initial = { cards: [c('B', { manualOrder: 0 }), c('A', { manualOrder: 1 })] };
+    const transaction = { events: [{ type: 'link_created', payload: { sourceId: 'A', targetId: 'B', anchorTarget: 'A', strategy: 'same_plateau_index' } }] };
+
+    const factOnly = applyTransaction(initial, transaction);
+    const resolved = resolveOrderAfterTransaction(factOnly, { transaction });
+
+    expect(ids(factOnly)).toEqual(['B', 'A']);
+    expect(factOnly.links).toEqual([{ id: 'A:B', sourceId: 'A', targetId: 'B', anchorTarget: 'A', anchorTargetId: undefined, strategy: 'same_plateau_index', status: 'active' }]);
+    expect(ids(resolved)).toEqual(['A', 'B']);
+  });
+
+  test('conflict_created crée une contrainte et le resolver applique le conflit', () => {
+    const initial = {
+      cards: [c('B', { manualOrder: 10 }), c('A', { manualOrder: 20 })],
+      links: [{ sourceId: 'A', targetId: 'B' }],
+    };
+    const transaction = { events: [{ type: 'conflict_created', payload: { sourceId: 'A', targetId: 'B' } }] };
+
+    const factOnly = applyTransaction(initial, transaction);
+    const resolved = resolveOrderAfterTransaction(factOnly, { transaction });
+
+    expect(ids(factOnly)).toEqual(['B', 'A']);
+    expect(factOnly.conflicts).toEqual([{ id: 'A:B', sourceId: 'A', targetId: 'B', anchorTargetId: undefined, status: 'active' }]);
+    expect(ids(resolved)).toEqual(['B', 'A']);
+    expect(resolved.orderWarnings).toEqual([{ code: 'LINK_CONFLICT_DIRECT', cardIds: ['A', 'B'] }]);
+  });
+
+  test('appearance_moved_between enregistre une intention puis le resolver finalise l’ordre', () => {
+    const initial = { cards: [c('B', { manualOrder: 0 }), c('A', { manualOrder: 10 })] };
+    const transaction = { events: [{ type: 'appearance_moved_between', payload: { appearanceId: 'A', beforeTargetId: 'B', manualOrder: -1 } }] };
+
+    const factOnly = applyTransaction(initial, transaction);
+    const resolved = resolveOrderAfterTransaction(factOnly, { transaction });
+
+    expect(ids(factOnly)).toEqual(['B', 'A']);
+    expect(factOnly.cards[1].manualOrderIntent).toEqual({ targetId: 'A', beforeTargetId: 'B', afterTargetId: undefined, anchorTargetId: 'A' });
+    expect(ids(resolved)).toEqual(['A', 'B']);
+  });
+
+  test('projectJamState rejoue le même event log sans interaction UX avec le même ordre final', () => {
+    const initial = { cards: [c('C', { manualOrder: 2 }), c('A', { manualOrder: 0 }), c('B', { manualOrder: 1 })] };
+    const eventLog = [
+      { events: [{ type: 'appearance_moved_between', payload: { appearanceId: 'C', manualOrder: -1 } }] },
+      { events: [{ type: 'link_created', payload: { sourceId: 'C', targetId: 'A', anchorTarget: 'C' } }] },
+      { events: [{ type: 'plateau_played', payload: { cardIds: ['C'] } }] },
+    ];
+
+    const first = projectJamState(initial, eventLog);
+    const second = projectJamState(initial, eventLog);
+
+    expect(first).toEqual(second);
+    expect(first.columns).toEqual(second.columns);
+    expect(first.columns[0].cards.map((card) => card.id)).toEqual(['C', 'A', 'B']);
+  });
+
+  test('helpers exposent des cibles, instruments et tris stables', () => {
+    const state = { cards: [
+      c('B', { columnId: 'chant', resolvedOrder: 2 }),
+      c('A', { columnId: 'chant', resolvedOrder: 1 }),
+      c('C', { columnId: 'guitare', status: 'hidden' }),
+    ] };
+
+    expect(cardTarget(state.cards[0])).toEqual({ type: 'card', id: 'B' });
+    expect(targetKey(cardTarget(state.cards[0]))).toBe('B');
+    expect(getInstrumentIdForCard(state.cards[0])).toBe('chant');
+    expect(getCardsByInstrument(state).chant.map((card) => card.id)).toEqual(['B', 'A']);
+    expect(sortCardsByCurrentResolvedOrder(state.cards).map((card) => card.id)).toEqual(['A', 'B', 'C']);
+    expect(isCardActive(state.cards[0])).toBe(true);
+    expect(isCardActive(state.cards[2])).toBe(false);
+    expect(isCardPlayed({ status: 'played' })).toBe(true);
+    expect(isCardLocked({ lockedAt: 1 })).toBe(true);
+  });
+
+  test('identifyAnchors prépare les events anchor demandés par le replay', () => {
+    const transaction = { events: [
+      { type: 'appearance_moved_between', payload: { appearanceId: 'A' } },
+      { type: 'hole_moved', payload: { holeId: 'H' } },
+      { type: 'link_created', payload: { anchorTarget: { id: 'L' } } },
+      { type: 'conflict_created', payload: { anchorTargetId: 'C' } },
+      { type: 'participation_added', payload: { newAppearanceIds: ['P', 'P2'] } },
+      { type: 'hole_added', payload: { holeId: 'HA' } },
+      { type: 'appearance_skipped', payload: { appearanceId: 'S' } },
+      { type: 'plateau_played', payload: { cardIds: ['PL'] } },
+    ] };
+
+    expect([...identifyAnchors({ transaction })].sort()).toEqual(['A', 'C', 'H', 'HA', 'L', 'P', 'PL', 'S']);
+  });
+
   test('replay identique deux fois', () => {
     const initial = { cards: [c('B', { manualOrder: 2 }), c('A', { manualOrder: 1 })] };
     const tx = { events: [{ type: 'card_moved', payload: { cardId: 'B' } }] };

--- a/frontend/src/features/projection/projectJamState.js
+++ b/frontend/src/features/projection/projectJamState.js
@@ -1,0 +1,47 @@
+const { applyTransaction } = require("./applyEvent");
+const { resolveOrderAfterTransaction, sortCardsByCurrentResolvedOrder } = require("./orderResolution");
+
+function materializeCalculatedAppearances(state) {
+  return state;
+}
+
+function isTransactionActive(transaction) {
+  return !(transaction && (transaction.undone || transaction.reverted || transaction.active === false));
+}
+
+function buildColumns(state) {
+  const cards = Array.isArray(state && state.cards) ? state.cards : [];
+  const columns = cards.reduce((acc, card) => {
+    const instrumentId = card.columnId || card.instrumentId || card.column || "default";
+    if (!acc[instrumentId]) {
+      acc[instrumentId] = { instrument: { instrumentId }, instrumentId, cards: [] };
+    }
+    acc[instrumentId].cards.push(card);
+    return acc;
+  }, {});
+  return {
+    ...state,
+    columns: Object.values(columns).map((column) => ({
+      ...column,
+      cards: sortCardsByCurrentResolvedOrder(column.cards),
+    })),
+  };
+}
+
+function projectJamState(initialState = {}, transactions = []) {
+  const projected = (Array.isArray(transactions) ? transactions : []).reduce((state, transaction) => {
+    if (!isTransactionActive(transaction)) {return state;}
+
+    const applied = applyTransaction(state, transaction);
+    const materialized = materializeCalculatedAppearances(applied);
+    return resolveOrderAfterTransaction(materialized, { transaction });
+  }, initialState);
+
+  return buildColumns(projected);
+}
+
+module.exports = {
+  projectJamState,
+  materializeCalculatedAppearances,
+  buildColumns,
+};

--- a/frontend/src/features/sync/localDb.js
+++ b/frontend/src/features/sync/localDb.js
@@ -1,0 +1,100 @@
+const jams = new Map();
+
+function transactionId(transaction) {
+  return transaction && (transaction.transactionId || transaction.id || transaction.clientTransactionId);
+}
+
+function transactionSequence(transaction, fallbackIndex) {
+  const serverSequence = transaction && (transaction.serverSequenceNumberStart ?? transaction.serverSequenceNumber);
+  if (Number.isFinite(serverSequence)) {return [0, serverSequence, fallbackIndex];}
+  const localSequence = transaction && (transaction.localSequence ?? transaction.localCreatedAt ?? transaction.createdAt);
+  return [1, Number.isFinite(localSequence) ? localSequence : fallbackIndex, fallbackIndex];
+}
+
+function compareTransactions(left, right) {
+  const leftKey = transactionSequence(left.transaction, left.index);
+  const rightKey = transactionSequence(right.transaction, right.index);
+  for (let index = 0; index < leftKey.length; index += 1) {
+    if (leftKey[index] < rightKey[index]) {return -1;}
+    if (leftKey[index] > rightKey[index]) {return 1;}
+  }
+  return String(transactionId(left.transaction)).localeCompare(String(transactionId(right.transaction)));
+}
+
+function normalizeBaseState(payload) {
+  if (payload && payload.initialState) {return payload.initialState;}
+  if (payload && payload.state) {return payload.state;}
+  if (payload && payload.cards) {return { cards: payload.cards };}
+  return { cards: [] };
+}
+
+function serverTransactionsFromPayload(payload) {
+  return Array.isArray(payload && payload.transactions) ? payload.transactions : [];
+}
+
+function getJamRecord(jamId) {
+  const key = String(jamId);
+  if (!jams.has(key)) {
+    jams.set(key, { baseState: { cards: [] }, transactions: new Map(), insertionIndex: 0 });
+  }
+  return jams.get(key);
+}
+
+function cloneTransaction(transaction) {
+  return { ...transaction, events: Array.isArray(transaction && transaction.events) ? transaction.events.map((event) => ({ ...event, payload: { ...(event.payload || {}) } })) : [] };
+}
+
+function putTransaction(record, transaction, defaults = {}) {
+  const id = transactionId(transaction);
+  if (!id) {return;}
+  const previous = record.transactions.get(id);
+  const insertionIndex = previous ? previous.insertionIndex : record.insertionIndex;
+  record.transactions.set(id, {
+    transaction: { ...(previous && previous.transaction), ...cloneTransaction(transaction), ...defaults },
+    insertionIndex,
+  });
+  if (!previous) {record.insertionIndex += 1;}
+}
+
+function resetLocalDb() {
+  jams.clear();
+}
+
+function addPendingTransaction(jamId, transaction) {
+  const record = getJamRecord(jamId);
+  putTransaction(record, transaction, { syncStatus: "pending" });
+}
+
+function persistServerPayload(jamId, payload) {
+  const record = getJamRecord(jamId);
+  record.baseState = normalizeBaseState(payload);
+  serverTransactionsFromPayload(payload).forEach((transaction) => {
+    putTransaction(record, transaction, { syncStatus: "synced" });
+  });
+}
+
+function getMergedTransactions(jamId) {
+  const record = getJamRecord(jamId);
+  return [...record.transactions.values()]
+    .map((entry) => ({ transaction: entry.transaction, index: entry.insertionIndex }))
+    .sort(compareTransactions)
+    .map((entry) => cloneTransaction(entry.transaction));
+}
+
+function getPendingTransactions(jamId) {
+  return getMergedTransactions(jamId).filter((transaction) => transaction.syncStatus === "pending");
+}
+
+function getBaseState(jamId) {
+  return getJamRecord(jamId).baseState;
+}
+
+module.exports = {
+  addPendingTransaction,
+  getBaseState,
+  getMergedTransactions,
+  getPendingTransactions,
+  persistServerPayload,
+  resetLocalDb,
+  transactionId,
+};

--- a/frontend/src/features/sync/syncQueue.js
+++ b/frontend/src/features/sync/syncQueue.js
@@ -1,0 +1,9 @@
+const { getPendingTransactions } = require("./localDb");
+
+function getPendingSyncQueue(jamId) {
+  return getPendingTransactions(jamId);
+}
+
+module.exports = {
+  getPendingSyncQueue,
+};


### PR DESCRIPTION
### Motivation

- Provide a local-first implementation of the Confiture-like pipeline to reproduce and test frontend replay/resolve behavior without backend or IndexedDB.
- Expose a deterministic projection pipeline that replays server + pending transactions and resolves visible order, links and conflicts.
- Add robust Jest test setup and a wrapper script to avoid passing unsupported CLI flags to Jest.

### Description

- Added an audit and design report `docs/action-pipeline-audit.md` describing the final pipeline and test coverage.
- Implemented event/application and projection stack: `applyEvent.js`, `orderResolution.js`, `projectJamState.js` and helper `buildColumns` to compute columns with `instrumentId` and stable resolved ordering, including frozen slot handling for played/locked cards and suppression of removed relations.
- Implemented an in-memory `localDb` and `syncQueue` (`sync/localDb.js`, `sync/syncQueue.js`) plus `jamStore.js` to hydrate server payloads, merge pending/server transactions and expose `applyLocalTransaction`, `hydrateFromPayload`, and `reloadFromLocalDb` APIs.
- Added test utilities and unit tests exercising the full pipeline and resolver: `features/jam/jamPipeline.test.js`, `features/jam/jamStore.test.js`, `features/projection/orderResolution.test.js`, and updated `AddReactionModal.test.js` expected text.
- Improved test environment and runner: `frontend/jest.setup.js` adds mocks for `Worker`, `URL.createObjectURL`, `HTMLCanvasElement.getContext` and `ResizeObserver`; `frontend/runJest.js` filters unsupported `--run` arg and invokes `jest --runInBand`; `package.json` `test` script now runs `node runJest.js`.

### Testing

- Ran the frontend test suite with `npm test` (which invokes `node runJest.js` -> `npx jest --runInBand`) covering the new tests and existing component tests. All tests passed.
- Exercised the new projection/unit tests: `frontend/src/features/jam/jamPipeline.test.js`, `frontend/src/features/jam/jamStore.test.js`, and `frontend/src/features/projection/orderResolution.test.js`, and they succeeded.
- Verified the modified component test `AddReactionModal.test.js` under the same Jest run and it also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32c0eb64b083329aab48923667f7f1)