### PR TITLE
Fix inline SVG PDF sticker exports

### DIFF
--- a/box_management/api/views/stickers.py
+++ b/box_management/api/views/stickers.py
@@ -155,6 +155,8 @@ class ClientAdminStickerDownloadView(APIView):
                 "cairosvg_missing": "L’export de stickers nécessite la dépendance Python cairosvg côté serveur pour générer les PNG et JPEG.",
                 "cairosvg_system_missing": "L’export de stickers nécessite les bibliothèques système Cairo sur le serveur pour générer les PNG et JPEG.",
                 "inkscape_missing": "L’export PDF nécessite Inkscape côté serveur.",
+                "inkscape_failed": "La génération PDF via Inkscape a échoué.",
+                "inkscape_blank_pdf": "Inkscape a généré un PDF vide pour le sticker.",
                 "sticker_cmyk_profile_missing": "L’export CMYK nécessite un profil ICC CMYK configuré côté serveur.",
                 "sticker_cmyk_profile_unreadable": "Le profil ICC CMYK configuré est introuvable ou illisible.",
                 "ghostscript_missing": "L’export CMYK nécessite Ghostscript côté serveur.",

--- a/box_management/services/stickers/export.py
+++ b/box_management/services/stickers/export.py
@@ -242,15 +242,80 @@ def build_stickers_zip_response(request, stickers, *, template, paper_size, file
     return response
 
 
-def build_pdf_wrapper_svg(sticker_svg_path, page_width_pt, page_height_pt):
-    href = Path(sticker_svg_path).as_uri()
-    return f'''<?xml version="1.0" encoding="UTF-8"?>\n<svg xmlns="{SVG_NS}" width="{page_width_pt}pt" height="{page_height_pt}pt" viewBox="0 0 {page_width_pt} {page_height_pt}">\n  <image href="{href}" x="0" y="0" width="{page_width_pt}" height="{page_height_pt}" preserveAspectRatio="xMidYMid meet"/>\n</svg>'''
+def get_svg_viewbox(root):
+    parts = re.split(r"[\s,]+", str(root.attrib.get("viewBox") or "").strip())
+    if len(parts) != 4:
+        raise ValueError("Le SVG sticker doit contenir un viewBox exploitable.")
+    min_x, min_y, width, height = [float(part) for part in parts]
+    if width <= 0 or height <= 0:
+        raise ValueError("Le viewBox du SVG sticker doit définir une largeur et une hauteur positives.")
+    return min_x, min_y, width, height
+
+
+def build_pdf_wrapper_svg(sticker_svg_bytes, page_width_pt, page_height_pt):
+    sticker_root = ET.fromstring(sticker_svg_bytes)
+    _min_x, _min_y, svg_width, svg_height = get_svg_viewbox(sticker_root)
+    scale = min(page_width_pt / svg_width, page_height_pt / svg_height)
+    rendered_width = svg_width * scale
+    rendered_height = svg_height * scale
+    x = (page_width_pt - rendered_width) / 2
+    y = (page_height_pt - rendered_height) / 2
+
+    wrapper = ET.Element(
+        f"{{{SVG_NS}}}svg",
+        {
+            "width": f"{page_width_pt}pt",
+            "height": f"{page_height_pt}pt",
+            "viewBox": f"0 0 {page_width_pt} {page_height_pt}",
+        },
+    )
+    wrapper.set(f"xmlns:xlink", XLINK_NS)
+    sticker_root.set("x", str(x))
+    sticker_root.set("y", str(y))
+    sticker_root.set("width", str(rendered_width))
+    sticker_root.set("height", str(rendered_height))
+    sticker_root.set("preserveAspectRatio", "xMidYMid meet")
+    wrapper.append(sticker_root)
+    return ET.tostring(wrapper, encoding="utf-8", xml_declaration=True)
 
 
 def export_svg_to_pdf_with_inkscape(input_svg, output_pdf):
     if not shutil.which("inkscape"):
         raise RuntimeError("inkscape_missing")
-    subprocess.run(["inkscape", str(input_svg), "--export-type=pdf", f"--export-filename={output_pdf}", "--export-text-to-path"], check=True, capture_output=True)
+    try:
+        subprocess.run(
+            ["inkscape", str(input_svg), "--export-type=pdf", f"--export-filename={output_pdf}", "--export-text-to-path"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError("inkscape_failed") from exc
+
+
+def _pdf_stream_bytes(contents):
+    if contents is None:
+        return b""
+    contents = contents.get_object()
+    if isinstance(contents, list):
+        return b"\n".join(item.get_object().get_data() for item in contents)
+    return contents.get_data()
+
+
+def assert_pdf_has_visible_content(pdf_path):
+    PdfReader, _PdfWriter = get_pypdf_writer()
+    reader = PdfReader(str(pdf_path))
+    if not reader.pages:
+        raise RuntimeError("inkscape_blank_pdf")
+    drawing_operators = {b"m", b"l", b"c", b"v", b"y", b"h", b"re", b"S", b"s", b"f", b"F", b"f*", b"B", b"B*", b"b", b"b*", b"Do", b"Tj", b"TJ", b"'", b'"'}
+    for page in reader.pages:
+        resources = page.get("/Resources")
+        content = _pdf_stream_bytes(page.get("/Contents"))
+        tokens = re.findall(rb"/?[A-Za-z0-9*'\"]+", content)
+        has_drawing_operator = any(token in drawing_operators for token in tokens)
+        if content.strip() and (has_drawing_operator or (resources and resources.get_object())):
+            return
+    raise RuntimeError("inkscape_blank_pdf")
 
 
 def build_stickers_pdf_bytes(request, stickers, *, template, paper_size, orientation):
@@ -264,12 +329,12 @@ def build_stickers_pdf_bytes(request, stickers, *, template, paper_size, orienta
         tmp_path = Path(tmp)
         for index, sticker in enumerate(stickers):
             sticker_svg, _w, _h = build_sticker_svg_bytes(sticker, template, request.build_absolute_uri(f"/s/{sticker.slug}"))
-            sticker_svg_path = tmp_path / f"sticker-{index}.svg"
             wrapper_svg_path = tmp_path / f"page-{index}.svg"
             page_pdf_path = tmp_path / f"page-{index}.pdf"
-            sticker_svg_path.write_bytes(sticker_svg)
-            wrapper_svg_path.write_text(build_pdf_wrapper_svg(sticker_svg_path, page_width_pt, page_height_pt), encoding="utf-8")
+            wrapper_svg = build_pdf_wrapper_svg(sticker_svg, page_width_pt, page_height_pt)
+            wrapper_svg_path.write_bytes(wrapper_svg)
             export_svg_to_pdf_with_inkscape(wrapper_svg_path, page_pdf_path)
+            assert_pdf_has_visible_content(page_pdf_path)
             for page in PdfReader(str(page_pdf_path)).pages:
                 writer.add_page(page)
         output = io.BytesIO()

--- a/box_management/tests/test_client_admin_stickers.py
+++ b/box_management/tests/test_client_admin_stickers.py
@@ -10,7 +10,12 @@ from django.test import override_settings
 from django.urls import reverse
 
 from box_management.models import ColorProfile, StickerTemplate
-from box_management.services.stickers.export import resolve_cmyk_icc_profile_path
+from box_management.services.stickers.export import (
+    assert_pdf_has_visible_content,
+    build_pdf_wrapper_svg,
+    build_stickers_pdf_bytes,
+    resolve_cmyk_icc_profile_path,
+)
 
 from .base import ClientAdminTestCase
 
@@ -163,6 +168,117 @@ class ClientAdminStickerTemplateApiTests(ClientAdminTestCase):
         self.assertEqual(response.data["results"], [])
 
 
+class StickerPdfExportUnitTests(ClientAdminTestCase):
+    def setUp(self):
+        super().setUp()
+        self.client_a = self.make_client(name="PDF export client", slug="pdf-export-client")
+        self.owner = self.make_client_user(username="pdf-export-owner", client=self.client_a)
+        self.sticker = self.make_sticker(client=self.client_a, slug="55555555555")
+
+    def sticker_svg_bytes(self):
+        return (
+            b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 200">'
+            b'<defs><style>.marker{fill:#000}</style></defs>'
+            b'<rect id="qr-zone" x="10" y="20" width="30" height="30" />'
+            b'<path id="visible-marker" class="marker" d="M0 0H100V20H0Z" />'
+            b'<image id="generated-qr" href="data:image/png;base64,AAAA" x="10" y="20" width="30" height="30" />'
+            b'</svg>'
+        )
+
+    def test_pdf_wrapper_is_inline_without_file_uri(self):
+        wrapper = build_pdf_wrapper_svg(self.sticker_svg_bytes(), 200, 300).decode("utf-8")
+
+        self.assertNotIn("file://", wrapper)
+        self.assertNotIn('<image href="file:', wrapper)
+        self.assertNotIn("as_uri", wrapper)
+        self.assertIn('id="qr-zone"', wrapper)
+        self.assertIn('id="generated-qr"', wrapper)
+        self.assertIn('id="visible-marker"', wrapper)
+
+    def test_pdf_wrapper_preserves_inline_svg_content(self):
+        wrapper = build_pdf_wrapper_svg(self.sticker_svg_bytes(), 100, 100).decode("utf-8")
+
+        self.assertIn('id="visible-marker"', wrapper)
+        self.assertIn('viewBox="0 0 100 200"', wrapper)
+        self.assertIn('preserveAspectRatio="xMidYMid meet"', wrapper)
+
+    @patch("box_management.services.stickers.export.get_pypdf_writer")
+    @patch("box_management.services.stickers.export.assert_pdf_has_visible_content")
+    @patch("box_management.services.stickers.export.export_svg_to_pdf_with_inkscape")
+    def test_build_stickers_pdf_bytes_writes_self_contained_wrapper(self, export_pdf, assert_content, get_pypdf):
+        template = self.make_sticker_template(clients=self.client_a, svg_content=self.sticker_svg_bytes().decode("utf-8"))
+        seen_wrappers = []
+
+        class FakeReader:
+            def __init__(self, _path):
+                self.pages = [object()]
+
+        class FakeWriter:
+            def __init__(self):
+                self.pages = []
+
+            def add_page(self, page):
+                self.pages.append(page)
+
+            def write(self, output):
+                output.write(b"pdf")
+
+        def fake_export(input_svg, output_pdf):
+            seen_wrappers.append(Path(input_svg).read_text(encoding="utf-8"))
+            Path(output_pdf).write_bytes(b"%PDF-1.4\n%test")
+
+        get_pypdf.return_value = (FakeReader, FakeWriter)
+        export_pdf.side_effect = fake_export
+        request = self.client.post("/").wsgi_request
+        build_stickers_pdf_bytes(request, [self.sticker], template=template, paper_size="A4", orientation="portrait")
+
+        self.assertEqual(len(seen_wrappers), 1)
+        self.assertIn('id="visible-marker"', seen_wrappers[0])
+        self.assertNotIn("file://", seen_wrappers[0])
+        self.assertNotIn("sticker-0.svg", seen_wrappers[0])
+        assert_content.assert_called_once()
+
+    @patch("box_management.services.stickers.export.get_pypdf_writer")
+    def test_assert_pdf_has_visible_content_rejects_blank_pdf(self, get_pypdf):
+        class BlankPage(dict):
+            def get(self, key):
+                return super().get(key)
+
+        class FakeReader:
+            def __init__(self, _path):
+                self.pages = [BlankPage({"/Contents": None, "/Resources": {}})]
+
+        get_pypdf.return_value = (FakeReader, object)
+
+        with self.assertRaisesRegex(RuntimeError, "inkscape_blank_pdf"):
+            assert_pdf_has_visible_content("blank.pdf")
+
+    @patch("box_management.services.stickers.export.get_pypdf_writer")
+    def test_assert_pdf_has_visible_content_accepts_non_empty_pdf(self, get_pypdf):
+        class FakeContents:
+            def get_object(self):
+                return self
+
+            def get_data(self):
+                return b"0 0 10 10 re f"
+
+        class FakeResources(dict):
+            def get_object(self):
+                return self
+
+        class NonEmptyPage(dict):
+            def get(self, key):
+                return super().get(key)
+
+        class FakeReader:
+            def __init__(self, _path):
+                self.pages = [NonEmptyPage({"/Contents": FakeContents(), "/Resources": FakeResources({"/ProcSet": []})})]
+
+        get_pypdf.return_value = (FakeReader, object)
+
+        assert_pdf_has_visible_content("non-empty.pdf")
+
+
 class ClientAdminStickerDownloadExportTests(ClientAdminTestCase):
     def setUp(self):
         self.client_a = self.make_client(name="Export A", slug="export-a")
@@ -257,6 +373,19 @@ class ClientAdminStickerDownloadExportTests(ClientAdminTestCase):
         response = self.post_download({"template_id": self.template.id, "file_type": "jpeg", "color_mode": "cmyk"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(build_zip.call_args.kwargs["file_type"], "jpeg")
+
+
+    @patch("box_management.api.views.stickers.build_stickers_pdf_response")
+    def test_inkscape_failed_returns_error(self, build_pdf):
+        build_pdf.side_effect = RuntimeError("inkscape_failed")
+        response = self.post_download({"template_id": self.template.id, "file_type": "pdf", "orientation": "portrait", "color_mode": "rgb"})
+        self.assert_api_error(response, 503, "INKSCAPE_FAILED")
+
+    @patch("box_management.api.views.stickers.build_stickers_pdf_response")
+    def test_inkscape_blank_pdf_returns_error(self, build_pdf):
+        build_pdf.side_effect = RuntimeError("inkscape_blank_pdf")
+        response = self.post_download({"template_id": self.template.id, "file_type": "pdf", "orientation": "portrait", "color_mode": "rgb"})
+        self.assert_api_error(response, 503, "INKSCAPE_BLANK_PDF")
 
     @patch("box_management.services.stickers.export.resolve_cmyk_icc_profile_path")
     @patch("box_management.services.stickers.export.convert_pdf_to_cmyk_with_ghostscript")


### PR DESCRIPTION
### Motivation
- PDF exports produced blank pages because the wrapper SVG referenced the sticker via an external `<image href="file://...">`, which Inkscape can render as an empty page. 
- The goal is to inline the sticker SVG into a page-sized wrapper so Inkscape receives a self-contained vector input and to detect blank PDFs early.

### Description
- Replace `build_pdf_wrapper_svg(sticker_svg_path, ...)` with `build_pdf_wrapper_svg(sticker_svg_bytes, ...)` that parses the sticker SVG, reads its `viewBox`, computes a centered `contain` scale, sets `x/y/width/height` and `preserveAspectRatio` and inlines the sticker element into a wrapper SVG; the wrapper is returned as UTF-8 bytes. (modified `box_management/services/stickers/export.py`)
- Update `build_stickers_pdf_bytes()` to write only the self-contained wrapper SVG (no `sticker-{i}.svg` files) and to call `export_svg_to_pdf_with_inkscape()` on that wrapper. (modified `box_management/services/stickers/export.py`)
- Improve `export_svg_to_pdf_with_inkscape()` to capture text output and raise `RuntimeError("inkscape_failed")` on CLI failure, and add `assert_pdf_has_visible_content()` which uses `pypdf` to perform a light check for content streams/resources and raise `RuntimeError("inkscape_blank_pdf")` if the PDF is structurally empty; `build_stickers_pdf_bytes()` calls this after Inkscape and before merging pages. (modified `box_management/services/stickers/export.py`)
- Surface new server-side errors `INKSCAPE_FAILED` and `INKSCAPE_BLANK_PDF` mapped to `503 Service Unavailable` in the sticker download view. (modified `box_management/api/views/stickers.py`)
- Add unit tests covering: the wrapper is inline and contains sticker content, wrapper preserves viewBox and attributes, `build_stickers_pdf_bytes()` writes a self-contained wrapper, `assert_pdf_has_visible_content()` rejects blank PDFs and accepts non-empty PDFs, and API-level mapping for the new error codes. (modified `box_management/tests/test_client_admin_stickers.py`)

### Testing
- Backend unit tests: ran `python manage.py test box_management.tests.test_client_admin_stickers` and the full `box_management.tests` suite; all backend tests passed (OK). 
- Frontend tests and build: ran `cd frontend && npm test` where most suites passed but one suite fails in the current test environment with `ReferenceError: Worker is not defined` when importing `heic2any` (this is an existing environment/test issue and unrelated to the backend change); `cd frontend && npm run build` completed successfully with Webpack warnings only. 
- Commands executed during validation: `python manage.py test box_management.tests.test_client_admin_stickers`, `python manage.py test box_management.tests`, `cd frontend && npm test`, and `cd frontend && npm run build`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42953fff0883328926be81870d4d3d)